### PR TITLE
0.19.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "bitbybit",
-    "version": "0.19.2",
+    "version": "0.19.3",
     "description": "Monorepo for browser CAD which holds bitbybit.dev npm packages",
     "main": "index.js",
     "scripts": {

--- a/packages/dev/babylonjs/lib/api/bitbybit/babylon/scene.ts
+++ b/packages/dev/babylonjs/lib/api/bitbybit/babylon/scene.ts
@@ -335,14 +335,14 @@ export class BabylonScene {
     enableSkybox(inputs: Inputs.BabylonScene.SkyboxDto): void {
         let texture: BABYLON.CubeTexture;
         if (inputs.skybox === Inputs.Base.skyboxEnum.default) {
-            texture = new BABYLON.CubeTexture("https://cdn.jsdelivr.net/gh/bitbybit-dev/bitbybit-assets@0.19.2/textures/skybox/default_skybox/skybox", this.context.scene);
+            texture = new BABYLON.CubeTexture("https://cdn.jsdelivr.net/gh/bitbybit-dev/bitbybit-assets@0.19.3/textures/skybox/default_skybox/skybox", this.context.scene);
         } else if (inputs.skybox === Inputs.Base.skyboxEnum.greyGradient) {
-            texture = new BABYLON.CubeTexture("https://cdn.jsdelivr.net/gh/bitbybit-dev/bitbybit-assets@0.19.2/textures/skybox/grey_gradient/skybox", this.context.scene);
+            texture = new BABYLON.CubeTexture("https://cdn.jsdelivr.net/gh/bitbybit-dev/bitbybit-assets@0.19.3/textures/skybox/grey_gradient/skybox", this.context.scene);
         } else if (inputs.skybox === Inputs.Base.skyboxEnum.clearSky) {
-            texture = BABYLON.CubeTexture.CreateFromPrefilteredData("https://cdn.jsdelivr.net/gh/bitbybit-dev/bitbybit-assets@0.19.2/textures/skybox/clear_sky/environment.env",
+            texture = BABYLON.CubeTexture.CreateFromPrefilteredData("https://cdn.jsdelivr.net/gh/bitbybit-dev/bitbybit-assets@0.19.3/textures/skybox/clear_sky/environment.env",
                 this.context.scene, false, false);
         } else if (inputs.skybox === Inputs.Base.skyboxEnum.city) {
-            texture = BABYLON.CubeTexture.CreateFromPrefilteredData("https://cdn.jsdelivr.net/gh/bitbybit-dev/bitbybit-assets@0.19.2/textures/skybox/city/environmentSpecular.env",
+            texture = BABYLON.CubeTexture.CreateFromPrefilteredData("https://cdn.jsdelivr.net/gh/bitbybit-dev/bitbybit-assets@0.19.3/textures/skybox/city/environmentSpecular.env",
                 this.context.scene, false, false);
         }
 

--- a/packages/dev/babylonjs/lib/api/bitbybit/draw.ts
+++ b/packages/dev/babylonjs/lib/api/bitbybit/draw.ts
@@ -49,6 +49,7 @@ export class Draw extends DrawCore {
      * @group draw async
      * @shortname draw async void
      * @disposableOutput true
+     * @drawable true
      */
     async drawAnyAsyncNoReturn(inputs: Inputs.Draw.DrawAny): Promise<void> {
         this.drawAnyAsync(inputs);
@@ -60,6 +61,7 @@ export class Draw extends DrawCore {
      * @returns BabylonJS Mesh Promise
      * @group draw async
      * @shortname draw async
+     * @drawable true
      * @disposableOutput true
      */
     async drawAnyAsync(inputs: Inputs.Draw.DrawAny): Promise<BABYLON.Mesh> {

--- a/packages/dev/babylonjs/lib/api/draw-helper.ts
+++ b/packages/dev/babylonjs/lib/api/draw-helper.ts
@@ -362,11 +362,13 @@ export class DrawHelper extends DrawHelperCore {
             },
             {
                 width,
+                materialType: BABYLON.GreasedLineMeshMaterialType.MATERIAL_TYPE_PBR,
                 color,
-
+                createAndAssignMaterial: true,
             },
             this.context.scene
         );
+        (result.material as BABYLON.PBRMaterial).albedoColor = color;
         result.material.alpha = visibility;
         return result as BABYLON.GreasedLineMesh;
     }

--- a/packages/dev/babylonjs/package-lock.json
+++ b/packages/dev/babylonjs/package-lock.json
@@ -1,21 +1,21 @@
 {
     "name": "@bitbybit-dev/babylonjs",
-    "version": "0.19.2",
+    "version": "0.19.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@bitbybit-dev/babylonjs",
-            "version": "0.19.2",
+            "version": "0.19.3",
             "license": "MIT",
             "dependencies": {
-                "@babylonjs/core": "7.45.0",
-                "@babylonjs/gui": "7.45.0",
+                "@babylonjs/core": "7.47.2",
+                "@babylonjs/gui": "7.47.2",
                 "@babylonjs/havok": "1.3.10",
-                "@babylonjs/loaders": "7.45.0",
-                "@babylonjs/materials": "7.45.0",
-                "@babylonjs/serializers": "7.45.0",
-                "@bitbybit-dev/core": "0.19.2",
+                "@babylonjs/loaders": "7.47.2",
+                "@babylonjs/materials": "7.47.2",
+                "@babylonjs/serializers": "7.47.2",
+                "@bitbybit-dev/core": "0.19.3",
                 "earcut": "2.2.3"
             },
             "devDependencies": {
@@ -1702,14 +1702,14 @@
             }
         },
         "node_modules/@babylonjs/core": {
-            "version": "7.45.0",
-            "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-7.45.0.tgz",
-            "integrity": "sha512-p5/7JEFPAhX8DFCpYor+N7S6pW8zjXELUGgjNnsu8DOvEKJ/G2LN3JDi/yvu1U/JUlXUVNZ9ul5q92uw5mLAtA=="
+            "version": "7.47.2",
+            "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-7.47.2.tgz",
+            "integrity": "sha512-R6anyhbOkKUCpmy0DPFSWwl3qxAd4Hs5pbef4M787aHSqiy1jURmLuUwg0tVsV6oiaZRSb00g8QyWW6TRdi1cw=="
         },
         "node_modules/@babylonjs/gui": {
-            "version": "7.45.0",
-            "resolved": "https://registry.npmjs.org/@babylonjs/gui/-/gui-7.45.0.tgz",
-            "integrity": "sha512-mJv5dHp7Jl+fGV6Pjs0u3uOvf9Dz/1ye8SqE7rcFCipcjsxLhLfaUAFsufNyxxgT1tkutF5WLWDP7KX11PMHPQ==",
+            "version": "7.47.2",
+            "resolved": "https://registry.npmjs.org/@babylonjs/gui/-/gui-7.47.2.tgz",
+            "integrity": "sha512-lY3o3v0K9JRbIK6JP0Wuo9mJxRFFaaCZqYBjLEOk9Nb/YsVJl9eNtEXWMtvPgFO6UhPwJbKEuudy6PDbX7eTDg==",
             "peerDependencies": {
                 "@babylonjs/core": "^7.0.0"
             }
@@ -1723,26 +1723,26 @@
             }
         },
         "node_modules/@babylonjs/loaders": {
-            "version": "7.45.0",
-            "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-7.45.0.tgz",
-            "integrity": "sha512-Xxh96aecZo8LL9uP7Ioq5v87PPRZLQKScd3EeZN5jYpQVLeTicHGAR1Ct/pUbegF7SA2jKk1vUxXVKs4sglVKw==",
+            "version": "7.47.2",
+            "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-7.47.2.tgz",
+            "integrity": "sha512-D8lkolWjOdSH8ZSuBy1v6FxeLfAAMph9nJIz2pu7sFNheMS1Z+8i1DBAyGeC7AL3DpeNnmL5AmBWagrOzfJtNQ==",
             "peerDependencies": {
                 "@babylonjs/core": "^7.0.0",
                 "babylonjs-gltf2interface": "^7.0.0"
             }
         },
         "node_modules/@babylonjs/materials": {
-            "version": "7.45.0",
-            "resolved": "https://registry.npmjs.org/@babylonjs/materials/-/materials-7.45.0.tgz",
-            "integrity": "sha512-lcOpnRb68cWFiAwgNJmSGj1WR/UK60USK3A/UQ16ft0RAv2HIvMTarF7BhDr8IDGYqrw9KEYpANO+LGJ9PfEyA==",
+            "version": "7.47.2",
+            "resolved": "https://registry.npmjs.org/@babylonjs/materials/-/materials-7.47.2.tgz",
+            "integrity": "sha512-ByyOml3FimZ6BMnVPZDwThSH9Ob22Mb8jCfbmSJk9qOwcLCKrnxutktJgxBr6/K0HQWjgvM6jYK3mKX7AbotcQ==",
             "peerDependencies": {
                 "@babylonjs/core": "^7.0.0"
             }
         },
         "node_modules/@babylonjs/serializers": {
-            "version": "7.45.0",
-            "resolved": "https://registry.npmjs.org/@babylonjs/serializers/-/serializers-7.45.0.tgz",
-            "integrity": "sha512-JsXau7AMSbXYskD1EXY7zDEnHFjIRROPHHZYUdgjuWaIqGM3FDrzdtdVTZAhXIZI1yVafjjhC7/FG+UxpfZa+w==",
+            "version": "7.47.2",
+            "resolved": "https://registry.npmjs.org/@babylonjs/serializers/-/serializers-7.47.2.tgz",
+            "integrity": "sha512-kGTcnj+RrBYHVytQc/hAyLk8R3mzXD7kIb9IbY8LfOP0up7pKzVrtlB/U1AL9CDLVQjAiZa+YwtKGZ5j3MGCiQ==",
             "peerDependencies": {
                 "@babylonjs/core": "^7.0.0",
                 "babylonjs-gltf2interface": "^7.0.0"
@@ -1755,30 +1755,30 @@
             "dev": true
         },
         "node_modules/@bitbybit-dev/base": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/base/-/base-0.19.2.tgz",
-            "integrity": "sha512-1fkGHec+ZtW5tfI6qPcy3sgkaWrYtL0Jy6nicJxKH21HCsCrCaQRq2yCU3vijBMMlyvImMo56uM0sbZRCTUpLQ=="
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/base/-/base-0.19.3.tgz",
+            "integrity": "sha512-5ALYrKg/8nD4c03yOuFTfaM0gTBq5IUFui8+6fUwE5HpZZy9NrKl9fo5tueELS5wHaXII2N7fCOEh6TxS0fpyQ=="
         },
         "node_modules/@bitbybit-dev/core": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/core/-/core-0.19.2.tgz",
-            "integrity": "sha512-zIw3RJhXwkKWAbeea7M9GQ+gDpauZzeAJNvapkG9H86JX4ng+u6dtoLkcaPBIKc3XWV7T7OG7VnzZCTJoG7wCA==",
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/core/-/core-0.19.3.tgz",
+            "integrity": "sha512-g4RwIALLxeg4YgKtlLmy+3dND7rjnCJ27iQj098AF8ICNohOtsULaNaTN5bxr4sSF3DbGVIoEu5h5vbbF/WWKQ==",
             "dependencies": {
-                "@bitbybit-dev/base": "0.19.2",
-                "@bitbybit-dev/jscad-worker": "0.19.2",
-                "@bitbybit-dev/manifold-worker": "0.19.2",
-                "@bitbybit-dev/occt-worker": "0.19.2",
+                "@bitbybit-dev/base": "0.19.3",
+                "@bitbybit-dev/jscad-worker": "0.19.3",
+                "@bitbybit-dev/manifold-worker": "0.19.3",
+                "@bitbybit-dev/occt-worker": "0.19.3",
                 "jsonpath-plus": "10.1.0",
                 "rxjs": "7.5.5",
                 "verb-nurbs-web": "2.1.3"
             }
         },
         "node_modules/@bitbybit-dev/jscad": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/jscad/-/jscad-0.19.2.tgz",
-            "integrity": "sha512-KHGY7W5NvkxAxvmN8XVZHq5EtC3W+OnRruDptBZvenNhQKZGkDQsuNjKfVhM6zWfoW31WV3C/Y6m090i8UWjlw==",
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/jscad/-/jscad-0.19.3.tgz",
+            "integrity": "sha512-x8jDMLPkPp98vw3Nwwawk19imcdq4QRsTXUjJieYzqVfN/0MslI+zZeoRmjRTUnYW+SpfLPfBpTKehbfJnF5yQ==",
             "dependencies": {
-                "@bitbybit-dev/base": "0.19.2",
+                "@bitbybit-dev/base": "0.19.3",
                 "@jscad/3mf-serializer": "2.1.12",
                 "@jscad/dxf-serializer": "2.1.18",
                 "@jscad/io-utils": "2.0.28",
@@ -1787,42 +1787,42 @@
             }
         },
         "node_modules/@bitbybit-dev/jscad-worker": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/jscad-worker/-/jscad-worker-0.19.2.tgz",
-            "integrity": "sha512-W66JixkiKqkpLS1Ile7tne01C68gfpbgJTvIYQMr/6jddxgA/MB7KpsSaqPyI6s7UVQgt6I/t9pmIJY1ijHAlQ==",
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/jscad-worker/-/jscad-worker-0.19.3.tgz",
+            "integrity": "sha512-UIc56Odk9FxJBjnJfc3Cd4lr/NzP846G59tGVql+pHqJ5xw9Dl1rHHDqy9n2JjGksDx/0i0q0hLWltywrSzdWQ==",
             "dependencies": {
-                "@bitbybit-dev/jscad": "0.19.2",
+                "@bitbybit-dev/jscad": "0.19.3",
                 "rxjs": "7.5.5"
             }
         },
         "node_modules/@bitbybit-dev/manifold": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/manifold/-/manifold-0.19.2.tgz",
-            "integrity": "sha512-7RzEOhmiEb8Mou+eRHft7+jWsNnXm0nIHWcMFvRtDfDrCF79dcBae3T175ZXBF2vDZP24rfcaeUyz35vH1qwCQ==",
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/manifold/-/manifold-0.19.3.tgz",
+            "integrity": "sha512-8FEUjwpJ0+QgzNCrzT3x2AYWsiDey2B8Nvx0uMa+s3xL3V1LGoCV+VBqk/aTwfzmTeOanI2MmUZuB7amUTWnHw==",
             "dependencies": {
                 "manifold-3d": "3.0.0"
             }
         },
         "node_modules/@bitbybit-dev/manifold-worker": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/manifold-worker/-/manifold-worker-0.19.2.tgz",
-            "integrity": "sha512-+Zi48ne6av+/Nj8KDXWYIjEHE/v8XMqVEzOq4cjayILLQ775/sxk/GA3KQ+q/wvq889n9jpMQPGk0shl+do6gQ==",
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/manifold-worker/-/manifold-worker-0.19.3.tgz",
+            "integrity": "sha512-7yDRnSTP1dv6k1Gk00HoBAIW8KwV3SDGDVOLT348+flrUMMU3X5EGhEgGHbBISLn/rzahfg0CFYxcHenB5HpOw==",
             "dependencies": {
-                "@bitbybit-dev/manifold": "0.19.2",
+                "@bitbybit-dev/manifold": "0.19.3",
                 "rxjs": "7.5.5"
             }
         },
         "node_modules/@bitbybit-dev/occt": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/occt/-/occt-0.19.2.tgz",
-            "integrity": "sha512-cn1YxdNnblWciusePkRo+TRE64rfrtqJFiP4MscoM1WSS7A7kgcUJlnX4Xam3ktPHtOWIE+3grahXTT5ndeTSQ=="
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/occt/-/occt-0.19.3.tgz",
+            "integrity": "sha512-pfXnidWliHshGeyft4EdkFwulRsqKqBZrrk4xAy11XaYZsL3xyHmTxj220t6CjCZ9SB5037NprDd9EQOHuTIKw=="
         },
         "node_modules/@bitbybit-dev/occt-worker": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/occt-worker/-/occt-worker-0.19.2.tgz",
-            "integrity": "sha512-QAd/P9hahotAmsG2ipQTo9m70y5l/aoD5HrdgXXkvaMMtHpMcMAHe10WHexWbTsJBdzCbecH7ukG1OJYfGoTEw==",
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/occt-worker/-/occt-worker-0.19.3.tgz",
+            "integrity": "sha512-usJ0f3WBUvBJ4F24J/8ZtXrxGxMyTbVaGz0x4zhRLfJmrHv/7I+M4y8qdSL+Zpe2jxecHxel+fno521t5vpCQQ==",
             "dependencies": {
-                "@bitbybit-dev/occt": "0.19.2",
+                "@bitbybit-dev/occt": "0.19.3",
                 "rxjs": "7.5.5"
             }
         },
@@ -8448,14 +8448,14 @@
             }
         },
         "@babylonjs/core": {
-            "version": "7.45.0",
-            "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-7.45.0.tgz",
-            "integrity": "sha512-p5/7JEFPAhX8DFCpYor+N7S6pW8zjXELUGgjNnsu8DOvEKJ/G2LN3JDi/yvu1U/JUlXUVNZ9ul5q92uw5mLAtA=="
+            "version": "7.47.2",
+            "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-7.47.2.tgz",
+            "integrity": "sha512-R6anyhbOkKUCpmy0DPFSWwl3qxAd4Hs5pbef4M787aHSqiy1jURmLuUwg0tVsV6oiaZRSb00g8QyWW6TRdi1cw=="
         },
         "@babylonjs/gui": {
-            "version": "7.45.0",
-            "resolved": "https://registry.npmjs.org/@babylonjs/gui/-/gui-7.45.0.tgz",
-            "integrity": "sha512-mJv5dHp7Jl+fGV6Pjs0u3uOvf9Dz/1ye8SqE7rcFCipcjsxLhLfaUAFsufNyxxgT1tkutF5WLWDP7KX11PMHPQ==",
+            "version": "7.47.2",
+            "resolved": "https://registry.npmjs.org/@babylonjs/gui/-/gui-7.47.2.tgz",
+            "integrity": "sha512-lY3o3v0K9JRbIK6JP0Wuo9mJxRFFaaCZqYBjLEOk9Nb/YsVJl9eNtEXWMtvPgFO6UhPwJbKEuudy6PDbX7eTDg==",
             "requires": {}
         },
         "@babylonjs/havok": {
@@ -8467,21 +8467,21 @@
             }
         },
         "@babylonjs/loaders": {
-            "version": "7.45.0",
-            "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-7.45.0.tgz",
-            "integrity": "sha512-Xxh96aecZo8LL9uP7Ioq5v87PPRZLQKScd3EeZN5jYpQVLeTicHGAR1Ct/pUbegF7SA2jKk1vUxXVKs4sglVKw==",
+            "version": "7.47.2",
+            "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-7.47.2.tgz",
+            "integrity": "sha512-D8lkolWjOdSH8ZSuBy1v6FxeLfAAMph9nJIz2pu7sFNheMS1Z+8i1DBAyGeC7AL3DpeNnmL5AmBWagrOzfJtNQ==",
             "requires": {}
         },
         "@babylonjs/materials": {
-            "version": "7.45.0",
-            "resolved": "https://registry.npmjs.org/@babylonjs/materials/-/materials-7.45.0.tgz",
-            "integrity": "sha512-lcOpnRb68cWFiAwgNJmSGj1WR/UK60USK3A/UQ16ft0RAv2HIvMTarF7BhDr8IDGYqrw9KEYpANO+LGJ9PfEyA==",
+            "version": "7.47.2",
+            "resolved": "https://registry.npmjs.org/@babylonjs/materials/-/materials-7.47.2.tgz",
+            "integrity": "sha512-ByyOml3FimZ6BMnVPZDwThSH9Ob22Mb8jCfbmSJk9qOwcLCKrnxutktJgxBr6/K0HQWjgvM6jYK3mKX7AbotcQ==",
             "requires": {}
         },
         "@babylonjs/serializers": {
-            "version": "7.45.0",
-            "resolved": "https://registry.npmjs.org/@babylonjs/serializers/-/serializers-7.45.0.tgz",
-            "integrity": "sha512-JsXau7AMSbXYskD1EXY7zDEnHFjIRROPHHZYUdgjuWaIqGM3FDrzdtdVTZAhXIZI1yVafjjhC7/FG+UxpfZa+w==",
+            "version": "7.47.2",
+            "resolved": "https://registry.npmjs.org/@babylonjs/serializers/-/serializers-7.47.2.tgz",
+            "integrity": "sha512-kGTcnj+RrBYHVytQc/hAyLk8R3mzXD7kIb9IbY8LfOP0up7pKzVrtlB/U1AL9CDLVQjAiZa+YwtKGZ5j3MGCiQ==",
             "requires": {}
         },
         "@bcoe/v8-coverage": {
@@ -8491,30 +8491,30 @@
             "dev": true
         },
         "@bitbybit-dev/base": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/base/-/base-0.19.2.tgz",
-            "integrity": "sha512-1fkGHec+ZtW5tfI6qPcy3sgkaWrYtL0Jy6nicJxKH21HCsCrCaQRq2yCU3vijBMMlyvImMo56uM0sbZRCTUpLQ=="
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/base/-/base-0.19.3.tgz",
+            "integrity": "sha512-5ALYrKg/8nD4c03yOuFTfaM0gTBq5IUFui8+6fUwE5HpZZy9NrKl9fo5tueELS5wHaXII2N7fCOEh6TxS0fpyQ=="
         },
         "@bitbybit-dev/core": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/core/-/core-0.19.2.tgz",
-            "integrity": "sha512-zIw3RJhXwkKWAbeea7M9GQ+gDpauZzeAJNvapkG9H86JX4ng+u6dtoLkcaPBIKc3XWV7T7OG7VnzZCTJoG7wCA==",
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/core/-/core-0.19.3.tgz",
+            "integrity": "sha512-g4RwIALLxeg4YgKtlLmy+3dND7rjnCJ27iQj098AF8ICNohOtsULaNaTN5bxr4sSF3DbGVIoEu5h5vbbF/WWKQ==",
             "requires": {
-                "@bitbybit-dev/base": "0.19.2",
-                "@bitbybit-dev/jscad-worker": "0.19.2",
-                "@bitbybit-dev/manifold-worker": "0.19.2",
-                "@bitbybit-dev/occt-worker": "0.19.2",
+                "@bitbybit-dev/base": "0.19.3",
+                "@bitbybit-dev/jscad-worker": "0.19.3",
+                "@bitbybit-dev/manifold-worker": "0.19.3",
+                "@bitbybit-dev/occt-worker": "0.19.3",
                 "jsonpath-plus": "10.1.0",
                 "rxjs": "7.5.5",
                 "verb-nurbs-web": "2.1.3"
             }
         },
         "@bitbybit-dev/jscad": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/jscad/-/jscad-0.19.2.tgz",
-            "integrity": "sha512-KHGY7W5NvkxAxvmN8XVZHq5EtC3W+OnRruDptBZvenNhQKZGkDQsuNjKfVhM6zWfoW31WV3C/Y6m090i8UWjlw==",
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/jscad/-/jscad-0.19.3.tgz",
+            "integrity": "sha512-x8jDMLPkPp98vw3Nwwawk19imcdq4QRsTXUjJieYzqVfN/0MslI+zZeoRmjRTUnYW+SpfLPfBpTKehbfJnF5yQ==",
             "requires": {
-                "@bitbybit-dev/base": "0.19.2",
+                "@bitbybit-dev/base": "0.19.3",
                 "@jscad/3mf-serializer": "2.1.12",
                 "@jscad/dxf-serializer": "2.1.18",
                 "@jscad/io-utils": "2.0.28",
@@ -8523,42 +8523,42 @@
             }
         },
         "@bitbybit-dev/jscad-worker": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/jscad-worker/-/jscad-worker-0.19.2.tgz",
-            "integrity": "sha512-W66JixkiKqkpLS1Ile7tne01C68gfpbgJTvIYQMr/6jddxgA/MB7KpsSaqPyI6s7UVQgt6I/t9pmIJY1ijHAlQ==",
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/jscad-worker/-/jscad-worker-0.19.3.tgz",
+            "integrity": "sha512-UIc56Odk9FxJBjnJfc3Cd4lr/NzP846G59tGVql+pHqJ5xw9Dl1rHHDqy9n2JjGksDx/0i0q0hLWltywrSzdWQ==",
             "requires": {
-                "@bitbybit-dev/jscad": "0.19.2",
+                "@bitbybit-dev/jscad": "0.19.3",
                 "rxjs": "7.5.5"
             }
         },
         "@bitbybit-dev/manifold": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/manifold/-/manifold-0.19.2.tgz",
-            "integrity": "sha512-7RzEOhmiEb8Mou+eRHft7+jWsNnXm0nIHWcMFvRtDfDrCF79dcBae3T175ZXBF2vDZP24rfcaeUyz35vH1qwCQ==",
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/manifold/-/manifold-0.19.3.tgz",
+            "integrity": "sha512-8FEUjwpJ0+QgzNCrzT3x2AYWsiDey2B8Nvx0uMa+s3xL3V1LGoCV+VBqk/aTwfzmTeOanI2MmUZuB7amUTWnHw==",
             "requires": {
                 "manifold-3d": "3.0.0"
             }
         },
         "@bitbybit-dev/manifold-worker": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/manifold-worker/-/manifold-worker-0.19.2.tgz",
-            "integrity": "sha512-+Zi48ne6av+/Nj8KDXWYIjEHE/v8XMqVEzOq4cjayILLQ775/sxk/GA3KQ+q/wvq889n9jpMQPGk0shl+do6gQ==",
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/manifold-worker/-/manifold-worker-0.19.3.tgz",
+            "integrity": "sha512-7yDRnSTP1dv6k1Gk00HoBAIW8KwV3SDGDVOLT348+flrUMMU3X5EGhEgGHbBISLn/rzahfg0CFYxcHenB5HpOw==",
             "requires": {
-                "@bitbybit-dev/manifold": "0.19.2",
+                "@bitbybit-dev/manifold": "0.19.3",
                 "rxjs": "7.5.5"
             }
         },
         "@bitbybit-dev/occt": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/occt/-/occt-0.19.2.tgz",
-            "integrity": "sha512-cn1YxdNnblWciusePkRo+TRE64rfrtqJFiP4MscoM1WSS7A7kgcUJlnX4Xam3ktPHtOWIE+3grahXTT5ndeTSQ=="
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/occt/-/occt-0.19.3.tgz",
+            "integrity": "sha512-pfXnidWliHshGeyft4EdkFwulRsqKqBZrrk4xAy11XaYZsL3xyHmTxj220t6CjCZ9SB5037NprDd9EQOHuTIKw=="
         },
         "@bitbybit-dev/occt-worker": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/occt-worker/-/occt-worker-0.19.2.tgz",
-            "integrity": "sha512-QAd/P9hahotAmsG2ipQTo9m70y5l/aoD5HrdgXXkvaMMtHpMcMAHe10WHexWbTsJBdzCbecH7ukG1OJYfGoTEw==",
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/occt-worker/-/occt-worker-0.19.3.tgz",
+            "integrity": "sha512-usJ0f3WBUvBJ4F24J/8ZtXrxGxMyTbVaGz0x4zhRLfJmrHv/7I+M4y8qdSL+Zpe2jxecHxel+fno521t5vpCQQ==",
             "requires": {
-                "@bitbybit-dev/occt": "0.19.2",
+                "@bitbybit-dev/occt": "0.19.3",
                 "rxjs": "7.5.5"
             }
         },

--- a/packages/dev/babylonjs/package.json
+++ b/packages/dev/babylonjs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bitbybit-dev/babylonjs",
-    "version": "0.19.2",
+    "version": "0.19.3",
     "description": "Bit By Bit Developers BABYLONJS CAD Library to Program Geometry",
     "main": "index.js",
     "repository": {
@@ -54,13 +54,13 @@
     "types": "./index.d.ts",
     "type": "module",
     "dependencies": {
-        "@babylonjs/core": "7.45.0",
-        "@babylonjs/gui": "7.45.0",
-        "@babylonjs/loaders": "7.45.0",
-        "@babylonjs/materials": "7.45.0",
-        "@babylonjs/serializers": "7.45.0",
+        "@babylonjs/core": "7.47.2",
+        "@babylonjs/gui": "7.47.2",
+        "@babylonjs/loaders": "7.47.2",
+        "@babylonjs/materials": "7.47.2",
+        "@babylonjs/serializers": "7.47.2",
         "@babylonjs/havok": "1.3.10",
-        "@bitbybit-dev/core": "0.19.2",
+        "@bitbybit-dev/core": "0.19.3",
         "earcut": "2.2.3"
     },
     "devDependencies": {

--- a/packages/dev/base/package-lock.json
+++ b/packages/dev/base/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@bitbybit-dev/base",
-    "version": "0.19.2",
+    "version": "0.19.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@bitbybit-dev/base",
-            "version": "0.19.2",
+            "version": "0.19.3",
             "license": "MIT",
             "devDependencies": {
                 "@babel/core": "7.16.0",

--- a/packages/dev/base/package.json
+++ b/packages/dev/base/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bitbybit-dev/base",
-    "version": "0.19.2",
+    "version": "0.19.3",
     "description": "Bit By Bit Developers Base CAD Library to Program Geometry",
     "main": "index.js",
     "repository": {

--- a/packages/dev/core/package-lock.json
+++ b/packages/dev/core/package-lock.json
@@ -1,18 +1,18 @@
 {
     "name": "@bitbybit-dev/core",
-    "version": "0.19.2",
+    "version": "0.19.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@bitbybit-dev/core",
-            "version": "0.19.2",
+            "version": "0.19.3",
             "license": "MIT",
             "dependencies": {
-                "@bitbybit-dev/base": "0.19.2",
-                "@bitbybit-dev/jscad-worker": "0.19.2",
-                "@bitbybit-dev/manifold-worker": "0.19.2",
-                "@bitbybit-dev/occt-worker": "0.19.2",
+                "@bitbybit-dev/base": "0.19.3",
+                "@bitbybit-dev/jscad-worker": "0.19.3",
+                "@bitbybit-dev/manifold-worker": "0.19.3",
+                "@bitbybit-dev/occt-worker": "0.19.3",
                 "jsonpath-plus": "10.1.0",
                 "rxjs": "7.5.5",
                 "verb-nurbs-web": "2.1.3"
@@ -1707,16 +1707,16 @@
             "dev": true
         },
         "node_modules/@bitbybit-dev/base": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/base/-/base-0.19.2.tgz",
-            "integrity": "sha512-1fkGHec+ZtW5tfI6qPcy3sgkaWrYtL0Jy6nicJxKH21HCsCrCaQRq2yCU3vijBMMlyvImMo56uM0sbZRCTUpLQ=="
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/base/-/base-0.19.3.tgz",
+            "integrity": "sha512-5ALYrKg/8nD4c03yOuFTfaM0gTBq5IUFui8+6fUwE5HpZZy9NrKl9fo5tueELS5wHaXII2N7fCOEh6TxS0fpyQ=="
         },
         "node_modules/@bitbybit-dev/jscad": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/jscad/-/jscad-0.19.2.tgz",
-            "integrity": "sha512-KHGY7W5NvkxAxvmN8XVZHq5EtC3W+OnRruDptBZvenNhQKZGkDQsuNjKfVhM6zWfoW31WV3C/Y6m090i8UWjlw==",
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/jscad/-/jscad-0.19.3.tgz",
+            "integrity": "sha512-x8jDMLPkPp98vw3Nwwawk19imcdq4QRsTXUjJieYzqVfN/0MslI+zZeoRmjRTUnYW+SpfLPfBpTKehbfJnF5yQ==",
             "dependencies": {
-                "@bitbybit-dev/base": "0.19.2",
+                "@bitbybit-dev/base": "0.19.3",
                 "@jscad/3mf-serializer": "2.1.12",
                 "@jscad/dxf-serializer": "2.1.18",
                 "@jscad/io-utils": "2.0.28",
@@ -1725,42 +1725,42 @@
             }
         },
         "node_modules/@bitbybit-dev/jscad-worker": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/jscad-worker/-/jscad-worker-0.19.2.tgz",
-            "integrity": "sha512-W66JixkiKqkpLS1Ile7tne01C68gfpbgJTvIYQMr/6jddxgA/MB7KpsSaqPyI6s7UVQgt6I/t9pmIJY1ijHAlQ==",
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/jscad-worker/-/jscad-worker-0.19.3.tgz",
+            "integrity": "sha512-UIc56Odk9FxJBjnJfc3Cd4lr/NzP846G59tGVql+pHqJ5xw9Dl1rHHDqy9n2JjGksDx/0i0q0hLWltywrSzdWQ==",
             "dependencies": {
-                "@bitbybit-dev/jscad": "0.19.2",
+                "@bitbybit-dev/jscad": "0.19.3",
                 "rxjs": "7.5.5"
             }
         },
         "node_modules/@bitbybit-dev/manifold": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/manifold/-/manifold-0.19.2.tgz",
-            "integrity": "sha512-7RzEOhmiEb8Mou+eRHft7+jWsNnXm0nIHWcMFvRtDfDrCF79dcBae3T175ZXBF2vDZP24rfcaeUyz35vH1qwCQ==",
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/manifold/-/manifold-0.19.3.tgz",
+            "integrity": "sha512-8FEUjwpJ0+QgzNCrzT3x2AYWsiDey2B8Nvx0uMa+s3xL3V1LGoCV+VBqk/aTwfzmTeOanI2MmUZuB7amUTWnHw==",
             "dependencies": {
                 "manifold-3d": "3.0.0"
             }
         },
         "node_modules/@bitbybit-dev/manifold-worker": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/manifold-worker/-/manifold-worker-0.19.2.tgz",
-            "integrity": "sha512-+Zi48ne6av+/Nj8KDXWYIjEHE/v8XMqVEzOq4cjayILLQ775/sxk/GA3KQ+q/wvq889n9jpMQPGk0shl+do6gQ==",
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/manifold-worker/-/manifold-worker-0.19.3.tgz",
+            "integrity": "sha512-7yDRnSTP1dv6k1Gk00HoBAIW8KwV3SDGDVOLT348+flrUMMU3X5EGhEgGHbBISLn/rzahfg0CFYxcHenB5HpOw==",
             "dependencies": {
-                "@bitbybit-dev/manifold": "0.19.2",
+                "@bitbybit-dev/manifold": "0.19.3",
                 "rxjs": "7.5.5"
             }
         },
         "node_modules/@bitbybit-dev/occt": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/occt/-/occt-0.19.2.tgz",
-            "integrity": "sha512-cn1YxdNnblWciusePkRo+TRE64rfrtqJFiP4MscoM1WSS7A7kgcUJlnX4Xam3ktPHtOWIE+3grahXTT5ndeTSQ=="
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/occt/-/occt-0.19.3.tgz",
+            "integrity": "sha512-pfXnidWliHshGeyft4EdkFwulRsqKqBZrrk4xAy11XaYZsL3xyHmTxj220t6CjCZ9SB5037NprDd9EQOHuTIKw=="
         },
         "node_modules/@bitbybit-dev/occt-worker": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/occt-worker/-/occt-worker-0.19.2.tgz",
-            "integrity": "sha512-QAd/P9hahotAmsG2ipQTo9m70y5l/aoD5HrdgXXkvaMMtHpMcMAHe10WHexWbTsJBdzCbecH7ukG1OJYfGoTEw==",
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/occt-worker/-/occt-worker-0.19.3.tgz",
+            "integrity": "sha512-usJ0f3WBUvBJ4F24J/8ZtXrxGxMyTbVaGz0x4zhRLfJmrHv/7I+M4y8qdSL+Zpe2jxecHxel+fno521t5vpCQQ==",
             "dependencies": {
-                "@bitbybit-dev/occt": "0.19.2",
+                "@bitbybit-dev/occt": "0.19.3",
                 "rxjs": "7.5.5"
             }
         },
@@ -8376,16 +8376,16 @@
             "dev": true
         },
         "@bitbybit-dev/base": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/base/-/base-0.19.2.tgz",
-            "integrity": "sha512-1fkGHec+ZtW5tfI6qPcy3sgkaWrYtL0Jy6nicJxKH21HCsCrCaQRq2yCU3vijBMMlyvImMo56uM0sbZRCTUpLQ=="
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/base/-/base-0.19.3.tgz",
+            "integrity": "sha512-5ALYrKg/8nD4c03yOuFTfaM0gTBq5IUFui8+6fUwE5HpZZy9NrKl9fo5tueELS5wHaXII2N7fCOEh6TxS0fpyQ=="
         },
         "@bitbybit-dev/jscad": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/jscad/-/jscad-0.19.2.tgz",
-            "integrity": "sha512-KHGY7W5NvkxAxvmN8XVZHq5EtC3W+OnRruDptBZvenNhQKZGkDQsuNjKfVhM6zWfoW31WV3C/Y6m090i8UWjlw==",
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/jscad/-/jscad-0.19.3.tgz",
+            "integrity": "sha512-x8jDMLPkPp98vw3Nwwawk19imcdq4QRsTXUjJieYzqVfN/0MslI+zZeoRmjRTUnYW+SpfLPfBpTKehbfJnF5yQ==",
             "requires": {
-                "@bitbybit-dev/base": "0.19.2",
+                "@bitbybit-dev/base": "0.19.3",
                 "@jscad/3mf-serializer": "2.1.12",
                 "@jscad/dxf-serializer": "2.1.18",
                 "@jscad/io-utils": "2.0.28",
@@ -8394,42 +8394,42 @@
             }
         },
         "@bitbybit-dev/jscad-worker": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/jscad-worker/-/jscad-worker-0.19.2.tgz",
-            "integrity": "sha512-W66JixkiKqkpLS1Ile7tne01C68gfpbgJTvIYQMr/6jddxgA/MB7KpsSaqPyI6s7UVQgt6I/t9pmIJY1ijHAlQ==",
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/jscad-worker/-/jscad-worker-0.19.3.tgz",
+            "integrity": "sha512-UIc56Odk9FxJBjnJfc3Cd4lr/NzP846G59tGVql+pHqJ5xw9Dl1rHHDqy9n2JjGksDx/0i0q0hLWltywrSzdWQ==",
             "requires": {
-                "@bitbybit-dev/jscad": "0.19.2",
+                "@bitbybit-dev/jscad": "0.19.3",
                 "rxjs": "7.5.5"
             }
         },
         "@bitbybit-dev/manifold": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/manifold/-/manifold-0.19.2.tgz",
-            "integrity": "sha512-7RzEOhmiEb8Mou+eRHft7+jWsNnXm0nIHWcMFvRtDfDrCF79dcBae3T175ZXBF2vDZP24rfcaeUyz35vH1qwCQ==",
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/manifold/-/manifold-0.19.3.tgz",
+            "integrity": "sha512-8FEUjwpJ0+QgzNCrzT3x2AYWsiDey2B8Nvx0uMa+s3xL3V1LGoCV+VBqk/aTwfzmTeOanI2MmUZuB7amUTWnHw==",
             "requires": {
                 "manifold-3d": "3.0.0"
             }
         },
         "@bitbybit-dev/manifold-worker": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/manifold-worker/-/manifold-worker-0.19.2.tgz",
-            "integrity": "sha512-+Zi48ne6av+/Nj8KDXWYIjEHE/v8XMqVEzOq4cjayILLQ775/sxk/GA3KQ+q/wvq889n9jpMQPGk0shl+do6gQ==",
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/manifold-worker/-/manifold-worker-0.19.3.tgz",
+            "integrity": "sha512-7yDRnSTP1dv6k1Gk00HoBAIW8KwV3SDGDVOLT348+flrUMMU3X5EGhEgGHbBISLn/rzahfg0CFYxcHenB5HpOw==",
             "requires": {
-                "@bitbybit-dev/manifold": "0.19.2",
+                "@bitbybit-dev/manifold": "0.19.3",
                 "rxjs": "7.5.5"
             }
         },
         "@bitbybit-dev/occt": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/occt/-/occt-0.19.2.tgz",
-            "integrity": "sha512-cn1YxdNnblWciusePkRo+TRE64rfrtqJFiP4MscoM1WSS7A7kgcUJlnX4Xam3ktPHtOWIE+3grahXTT5ndeTSQ=="
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/occt/-/occt-0.19.3.tgz",
+            "integrity": "sha512-pfXnidWliHshGeyft4EdkFwulRsqKqBZrrk4xAy11XaYZsL3xyHmTxj220t6CjCZ9SB5037NprDd9EQOHuTIKw=="
         },
         "@bitbybit-dev/occt-worker": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/occt-worker/-/occt-worker-0.19.2.tgz",
-            "integrity": "sha512-QAd/P9hahotAmsG2ipQTo9m70y5l/aoD5HrdgXXkvaMMtHpMcMAHe10WHexWbTsJBdzCbecH7ukG1OJYfGoTEw==",
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/occt-worker/-/occt-worker-0.19.3.tgz",
+            "integrity": "sha512-usJ0f3WBUvBJ4F24J/8ZtXrxGxMyTbVaGz0x4zhRLfJmrHv/7I+M4y8qdSL+Zpe2jxecHxel+fno521t5vpCQQ==",
             "requires": {
-                "@bitbybit-dev/occt": "0.19.2",
+                "@bitbybit-dev/occt": "0.19.3",
                 "rxjs": "7.5.5"
             }
         },

--- a/packages/dev/core/package.json
+++ b/packages/dev/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bitbybit-dev/core",
-    "version": "0.19.2",
+    "version": "0.19.3",
     "description": "Bit By Bit Developers Core CAD API to Program Geometry",
     "main": "index.js",
     "repository": {
@@ -54,10 +54,10 @@
     "types": "./index.d.ts",
     "type": "module",
     "dependencies": {
-        "@bitbybit-dev/base": "0.19.2",
-        "@bitbybit-dev/occt-worker": "0.19.2",
-        "@bitbybit-dev/manifold-worker": "0.19.2",
-        "@bitbybit-dev/jscad-worker": "0.19.2",
+        "@bitbybit-dev/base": "0.19.3",
+        "@bitbybit-dev/occt-worker": "0.19.3",
+        "@bitbybit-dev/manifold-worker": "0.19.3",
+        "@bitbybit-dev/jscad-worker": "0.19.3",
         "jsonpath-plus": "10.1.0",
         "verb-nurbs-web": "2.1.3",
         "rxjs": "7.5.5"

--- a/packages/dev/jscad-worker/package-lock.json
+++ b/packages/dev/jscad-worker/package-lock.json
@@ -1,15 +1,15 @@
 {
     "name": "@bitbybit-dev/jscad-worker",
-    "version": "0.19.2",
+    "version": "0.19.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@bitbybit-dev/jscad-worker",
-            "version": "0.19.2",
+            "version": "0.19.3",
             "license": "MIT",
             "dependencies": {
-                "@bitbybit-dev/jscad": "0.19.2",
+                "@bitbybit-dev/jscad": "0.19.3",
                 "rxjs": "7.5.5"
             },
             "devDependencies": {
@@ -1702,16 +1702,16 @@
             "dev": true
         },
         "node_modules/@bitbybit-dev/base": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/base/-/base-0.19.2.tgz",
-            "integrity": "sha512-1fkGHec+ZtW5tfI6qPcy3sgkaWrYtL0Jy6nicJxKH21HCsCrCaQRq2yCU3vijBMMlyvImMo56uM0sbZRCTUpLQ=="
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/base/-/base-0.19.3.tgz",
+            "integrity": "sha512-5ALYrKg/8nD4c03yOuFTfaM0gTBq5IUFui8+6fUwE5HpZZy9NrKl9fo5tueELS5wHaXII2N7fCOEh6TxS0fpyQ=="
         },
         "node_modules/@bitbybit-dev/jscad": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/jscad/-/jscad-0.19.2.tgz",
-            "integrity": "sha512-KHGY7W5NvkxAxvmN8XVZHq5EtC3W+OnRruDptBZvenNhQKZGkDQsuNjKfVhM6zWfoW31WV3C/Y6m090i8UWjlw==",
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/jscad/-/jscad-0.19.3.tgz",
+            "integrity": "sha512-x8jDMLPkPp98vw3Nwwawk19imcdq4QRsTXUjJieYzqVfN/0MslI+zZeoRmjRTUnYW+SpfLPfBpTKehbfJnF5yQ==",
             "dependencies": {
-                "@bitbybit-dev/base": "0.19.2",
+                "@bitbybit-dev/base": "0.19.3",
                 "@jscad/3mf-serializer": "2.1.12",
                 "@jscad/dxf-serializer": "2.1.18",
                 "@jscad/io-utils": "2.0.28",
@@ -8236,16 +8236,16 @@
             "dev": true
         },
         "@bitbybit-dev/base": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/base/-/base-0.19.2.tgz",
-            "integrity": "sha512-1fkGHec+ZtW5tfI6qPcy3sgkaWrYtL0Jy6nicJxKH21HCsCrCaQRq2yCU3vijBMMlyvImMo56uM0sbZRCTUpLQ=="
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/base/-/base-0.19.3.tgz",
+            "integrity": "sha512-5ALYrKg/8nD4c03yOuFTfaM0gTBq5IUFui8+6fUwE5HpZZy9NrKl9fo5tueELS5wHaXII2N7fCOEh6TxS0fpyQ=="
         },
         "@bitbybit-dev/jscad": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/jscad/-/jscad-0.19.2.tgz",
-            "integrity": "sha512-KHGY7W5NvkxAxvmN8XVZHq5EtC3W+OnRruDptBZvenNhQKZGkDQsuNjKfVhM6zWfoW31WV3C/Y6m090i8UWjlw==",
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/jscad/-/jscad-0.19.3.tgz",
+            "integrity": "sha512-x8jDMLPkPp98vw3Nwwawk19imcdq4QRsTXUjJieYzqVfN/0MslI+zZeoRmjRTUnYW+SpfLPfBpTKehbfJnF5yQ==",
             "requires": {
-                "@bitbybit-dev/base": "0.19.2",
+                "@bitbybit-dev/base": "0.19.3",
                 "@jscad/3mf-serializer": "2.1.12",
                 "@jscad/dxf-serializer": "2.1.18",
                 "@jscad/io-utils": "2.0.28",

--- a/packages/dev/jscad-worker/package.json
+++ b/packages/dev/jscad-worker/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bitbybit-dev/jscad-worker",
-    "version": "0.19.2",
+    "version": "0.19.3",
     "description": "Bit By Bit Developers JSCAD Based CAD Library to Program Geometry Via WebWorker",
     "main": "index.js",
     "repository": {
@@ -60,7 +60,7 @@
     "types": "./index.d.ts",
     "type": "module",
     "dependencies": {
-        "@bitbybit-dev/jscad": "0.19.2",
+        "@bitbybit-dev/jscad": "0.19.3",
         "rxjs": "7.5.5"
     },
     "devDependencies": {

--- a/packages/dev/jscad/package-lock.json
+++ b/packages/dev/jscad/package-lock.json
@@ -1,15 +1,15 @@
 {
     "name": "@bitbybit-dev/jscad",
-    "version": "0.19.2",
+    "version": "0.19.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@bitbybit-dev/jscad",
-            "version": "0.19.2",
+            "version": "0.19.3",
             "license": "MIT",
             "dependencies": {
-                "@bitbybit-dev/base": "0.19.2",
+                "@bitbybit-dev/base": "0.19.3",
                 "@jscad/3mf-serializer": "2.1.12",
                 "@jscad/dxf-serializer": "2.1.18",
                 "@jscad/io-utils": "2.0.28",
@@ -1706,9 +1706,9 @@
             "dev": true
         },
         "node_modules/@bitbybit-dev/base": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/base/-/base-0.19.2.tgz",
-            "integrity": "sha512-1fkGHec+ZtW5tfI6qPcy3sgkaWrYtL0Jy6nicJxKH21HCsCrCaQRq2yCU3vijBMMlyvImMo56uM0sbZRCTUpLQ=="
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/base/-/base-0.19.3.tgz",
+            "integrity": "sha512-5ALYrKg/8nD4c03yOuFTfaM0gTBq5IUFui8+6fUwE5HpZZy9NrKl9fo5tueELS5wHaXII2N7fCOEh6TxS0fpyQ=="
         },
         "node_modules/@cspotcode/source-map-support": {
             "version": "0.8.1",
@@ -8214,9 +8214,9 @@
             "dev": true
         },
         "@bitbybit-dev/base": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/base/-/base-0.19.2.tgz",
-            "integrity": "sha512-1fkGHec+ZtW5tfI6qPcy3sgkaWrYtL0Jy6nicJxKH21HCsCrCaQRq2yCU3vijBMMlyvImMo56uM0sbZRCTUpLQ=="
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/base/-/base-0.19.3.tgz",
+            "integrity": "sha512-5ALYrKg/8nD4c03yOuFTfaM0gTBq5IUFui8+6fUwE5HpZZy9NrKl9fo5tueELS5wHaXII2N7fCOEh6TxS0fpyQ=="
         },
         "@cspotcode/source-map-support": {
             "version": "0.8.1",

--- a/packages/dev/jscad/package.json
+++ b/packages/dev/jscad/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bitbybit-dev/jscad",
-    "version": "0.19.2",
+    "version": "0.19.3",
     "description": "Bit By Bit Developers JSCAD based CAD Library to Program Geometry",
     "main": "index.js",
     "repository": {
@@ -58,7 +58,7 @@
     "types": "./index.d.ts",
     "type": "module",
     "dependencies": {
-        "@bitbybit-dev/base": "0.19.2",
+        "@bitbybit-dev/base": "0.19.3",
         "@jscad/io-utils": "2.0.28",
         "@jscad/modeling": "2.12.3",
         "@jscad/stl-serializer": "2.1.18",

--- a/packages/dev/manifold-worker/package-lock.json
+++ b/packages/dev/manifold-worker/package-lock.json
@@ -1,15 +1,15 @@
 {
     "name": "@bitbybit-dev/manifold-worker",
-    "version": "0.19.2",
+    "version": "0.19.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@bitbybit-dev/manifold-worker",
-            "version": "0.19.2",
+            "version": "0.19.3",
             "license": "MIT",
             "dependencies": {
-                "@bitbybit-dev/manifold": "0.19.2",
+                "@bitbybit-dev/manifold": "0.19.3",
                 "rxjs": "7.5.5"
             },
             "devDependencies": {
@@ -1702,9 +1702,9 @@
             "dev": true
         },
         "node_modules/@bitbybit-dev/manifold": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/manifold/-/manifold-0.19.2.tgz",
-            "integrity": "sha512-7RzEOhmiEb8Mou+eRHft7+jWsNnXm0nIHWcMFvRtDfDrCF79dcBae3T175ZXBF2vDZP24rfcaeUyz35vH1qwCQ==",
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/manifold/-/manifold-0.19.3.tgz",
+            "integrity": "sha512-8FEUjwpJ0+QgzNCrzT3x2AYWsiDey2B8Nvx0uMa+s3xL3V1LGoCV+VBqk/aTwfzmTeOanI2MmUZuB7amUTWnHw==",
             "dependencies": {
                 "manifold-3d": "3.0.0"
             }
@@ -8169,9 +8169,9 @@
             "dev": true
         },
         "@bitbybit-dev/manifold": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/manifold/-/manifold-0.19.2.tgz",
-            "integrity": "sha512-7RzEOhmiEb8Mou+eRHft7+jWsNnXm0nIHWcMFvRtDfDrCF79dcBae3T175ZXBF2vDZP24rfcaeUyz35vH1qwCQ==",
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/manifold/-/manifold-0.19.3.tgz",
+            "integrity": "sha512-8FEUjwpJ0+QgzNCrzT3x2AYWsiDey2B8Nvx0uMa+s3xL3V1LGoCV+VBqk/aTwfzmTeOanI2MmUZuB7amUTWnHw==",
             "requires": {
                 "manifold-3d": "3.0.0"
             }

--- a/packages/dev/manifold-worker/package.json
+++ b/packages/dev/manifold-worker/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bitbybit-dev/manifold-worker",
-    "version": "0.19.2",
+    "version": "0.19.3",
     "description": "Bit By Bit Developers Manifold Based CAD Library to Program Geometry Via WebWorker",
     "main": "index.js",
     "repository": {
@@ -60,7 +60,7 @@
     "types": "./index.d.ts",
     "type": "module",
     "dependencies": {
-        "@bitbybit-dev/manifold": "0.19.2",
+        "@bitbybit-dev/manifold": "0.19.3",
         "rxjs": "7.5.5"
     },
     "devDependencies": {

--- a/packages/dev/manifold/package-lock.json
+++ b/packages/dev/manifold/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@bitbybit-dev/manifold",
-    "version": "0.19.2",
+    "version": "0.19.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@bitbybit-dev/manifold",
-            "version": "0.19.2",
+            "version": "0.19.3",
             "license": "MIT",
             "dependencies": {
                 "manifold-3d": "3.0.0"

--- a/packages/dev/manifold/package.json
+++ b/packages/dev/manifold/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bitbybit-dev/manifold",
-    "version": "0.19.2",
+    "version": "0.19.3",
     "description": "Bit By Bit Developers Manifold based CAD Library to Program Geometry",
     "main": "index.js",
     "repository": {

--- a/packages/dev/occt-worker/lib/api/occt/operations.ts
+++ b/packages/dev/occt-worker/lib/api/occt/operations.ts
@@ -105,14 +105,14 @@ export class OCCTOperations {
     }
 
     /**
-     * Splits the face with edges
-     * @param inputs Face to split and edges to split with
-     * @returns Resulting split shape
+     * Splits the shape with shapes
+     * @param inputs Shape to split and shapes to split with
+     * @returns Resulting shapes
      * @group divisions
      * @shortname split
      * @drawable true
      */
-    splitShapeWithShapes(inputs: Inputs.OCCT.SplitDto<Inputs.OCCT.TopoDSShapePointer>): Promise<Inputs.OCCT.TopoDSShapePointer> {
+    splitShapeWithShapes(inputs: Inputs.OCCT.SplitDto<Inputs.OCCT.TopoDSShapePointer>): Promise<Inputs.OCCT.TopoDSShapePointer[]> {
         return this.occWorkerManager.genericCallToWorkerPromise("operations.splitShapeWithShapes", inputs);
     }
 

--- a/packages/dev/occt-worker/lib/api/occt/shapes/compound.ts
+++ b/packages/dev/occt-worker/lib/api/occt/shapes/compound.ts
@@ -20,4 +20,15 @@ export class OCCTCompound {
         return this.occWorkerManager.genericCallToWorkerPromise("shapes.compound.makeCompound", inputs);
     }
 
+    /**
+     * Gets the shapes that compound is made of
+     * @param inputs OpenCascade shapes
+     * @returns OpenCascade compounded shape
+     * @group get
+     * @shortname get shapes of compound
+     * @drawable true
+     */
+    getShapesOfCompound(inputs: Inputs.OCCT.ShapeDto<Inputs.OCCT.TopoDSCompoundPointer>): Promise<Inputs.OCCT.TopoDSShapePointer[]> {
+        return this.occWorkerManager.genericCallToWorkerPromise("shapes.compound.getShapesOfCompound", inputs);
+    }
 }

--- a/packages/dev/occt-worker/package-lock.json
+++ b/packages/dev/occt-worker/package-lock.json
@@ -1,15 +1,15 @@
 {
     "name": "@bitbybit-dev/occt-worker",
-    "version": "0.19.2",
+    "version": "0.19.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@bitbybit-dev/occt-worker",
-            "version": "0.19.2",
+            "version": "0.19.3",
             "license": "MIT",
             "dependencies": {
-                "@bitbybit-dev/occt": "0.19.2",
+                "@bitbybit-dev/occt": "0.19.3",
                 "rxjs": "7.5.5"
             },
             "devDependencies": {
@@ -1702,9 +1702,9 @@
             "dev": true
         },
         "node_modules/@bitbybit-dev/occt": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/occt/-/occt-0.19.2.tgz",
-            "integrity": "sha512-cn1YxdNnblWciusePkRo+TRE64rfrtqJFiP4MscoM1WSS7A7kgcUJlnX4Xam3ktPHtOWIE+3grahXTT5ndeTSQ=="
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/occt/-/occt-0.19.3.tgz",
+            "integrity": "sha512-pfXnidWliHshGeyft4EdkFwulRsqKqBZrrk4xAy11XaYZsL3xyHmTxj220t6CjCZ9SB5037NprDd9EQOHuTIKw=="
         },
         "node_modules/@cspotcode/source-map-support": {
             "version": "0.8.1",
@@ -8161,9 +8161,9 @@
             "dev": true
         },
         "@bitbybit-dev/occt": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/occt/-/occt-0.19.2.tgz",
-            "integrity": "sha512-cn1YxdNnblWciusePkRo+TRE64rfrtqJFiP4MscoM1WSS7A7kgcUJlnX4Xam3ktPHtOWIE+3grahXTT5ndeTSQ=="
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/occt/-/occt-0.19.3.tgz",
+            "integrity": "sha512-pfXnidWliHshGeyft4EdkFwulRsqKqBZrrk4xAy11XaYZsL3xyHmTxj220t6CjCZ9SB5037NprDd9EQOHuTIKw=="
         },
         "@cspotcode/source-map-support": {
             "version": "0.8.1",

--- a/packages/dev/occt-worker/package.json
+++ b/packages/dev/occt-worker/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bitbybit-dev/occt-worker",
-    "version": "0.19.2",
+    "version": "0.19.3",
     "description": "Bit By Bit Developers CAD algorithms using OpenCascade Technology kernel adapted for WebWorker",
     "main": "index.js",
     "repository": {
@@ -56,7 +56,7 @@
     "types": "./index.d.ts",
     "type": "module",
     "dependencies": {
-        "@bitbybit-dev/occt": "0.19.2",
+        "@bitbybit-dev/occt": "0.19.3",
         "rxjs": "7.5.5"
     },
     "devDependencies": {

--- a/packages/dev/occt/bitbybit-dev-occt/bitbybit-dev-occt.d.ts
+++ b/packages/dev/occt/bitbybit-dev-occt/bitbybit-dev-occt.d.ts
@@ -3901,6 +3901,413 @@ export declare class TColStd_IndexedDataMapOfStringString extends NCollection_Ba
     constructor(theOther: TColStd_IndexedDataMapOfStringString);
   }
 
+export declare type BOPAlgo_GlueEnum = {
+  BOPAlgo_GlueOff: {};
+  BOPAlgo_GlueShift: {};
+  BOPAlgo_GlueFull: {};
+}
+
+export declare class BOPAlgo_Algo extends BOPAlgo_Options {
+  Perform(theRange: Message_ProgressRange): void;
+  delete(): void;
+}
+
+export declare class BOPAlgo_WireEdgeSet {
+  Clear(): void;
+  SetFace(aF: TopoDS_Face): void;
+  Face(): TopoDS_Face;
+  AddStartElement(sS: TopoDS_Shape): void;
+  StartElements(): TopTools_ListOfShape;
+  AddShape(sS: TopoDS_Shape): void;
+  Shapes(): TopTools_ListOfShape;
+  delete(): void;
+}
+
+  export declare class BOPAlgo_WireEdgeSet_1 extends BOPAlgo_WireEdgeSet {
+    constructor();
+  }
+
+  export declare class BOPAlgo_WireEdgeSet_2 extends BOPAlgo_WireEdgeSet {
+    constructor(theAllocator: Handle_NCollection_BaseAllocator);
+  }
+
+export declare class BOPAlgo_WireSplitter extends BOPAlgo_Algo {
+  SetWES(theWES: BOPAlgo_WireEdgeSet): void;
+  WES(): BOPAlgo_WireEdgeSet;
+  SetContext(theContext: Handle_IntTools_Context): void;
+  Context(): Handle_IntTools_Context;
+  Perform(theRange: Message_ProgressRange): void;
+  static MakeWire(theLE: TopTools_ListOfShape, theW: TopoDS_Wire): void;
+  static SplitBlock(theF: TopoDS_Face, theCB: BOPTools_ConnexityBlock, theContext: Handle_IntTools_Context): void;
+  delete(): void;
+}
+
+  export declare class BOPAlgo_WireSplitter_1 extends BOPAlgo_WireSplitter {
+    constructor();
+  }
+
+  export declare class BOPAlgo_WireSplitter_2 extends BOPAlgo_WireSplitter {
+    constructor(theAllocator: Handle_NCollection_BaseAllocator);
+  }
+
+export declare class BOPAlgo_ListOfCheckResult extends NCollection_BaseList {
+  begin(): any;
+  end(): any;
+  cbegin(): any;
+  cend(): any;
+  Size(): Standard_Integer;
+  Assign(theOther: BOPAlgo_ListOfCheckResult): BOPAlgo_ListOfCheckResult;
+  Clear(theAllocator: Handle_NCollection_BaseAllocator): void;
+  First_1(): BOPAlgo_CheckResult;
+  First_2(): BOPAlgo_CheckResult;
+  Last_1(): BOPAlgo_CheckResult;
+  Last_2(): BOPAlgo_CheckResult;
+  Append_1(theItem: BOPAlgo_CheckResult): BOPAlgo_CheckResult;
+  Append_3(theOther: BOPAlgo_ListOfCheckResult): void;
+  Prepend_1(theItem: BOPAlgo_CheckResult): BOPAlgo_CheckResult;
+  Prepend_2(theOther: BOPAlgo_ListOfCheckResult): void;
+  RemoveFirst(): void;
+  Reverse(): void;
+  delete(): void;
+}
+
+  export declare class BOPAlgo_ListOfCheckResult_1 extends BOPAlgo_ListOfCheckResult {
+    constructor();
+  }
+
+  export declare class BOPAlgo_ListOfCheckResult_2 extends BOPAlgo_ListOfCheckResult {
+    constructor(theAllocator: Handle_NCollection_BaseAllocator);
+  }
+
+  export declare class BOPAlgo_ListOfCheckResult_3 extends BOPAlgo_ListOfCheckResult {
+    constructor(theOther: BOPAlgo_ListOfCheckResult);
+  }
+
+export declare class BOPAlgo_SectionAttribute {
+  Approximation_1(theApprox: Standard_Boolean): void;
+  PCurveOnS1_1(thePCurveOnS1: Standard_Boolean): void;
+  PCurveOnS2_1(thePCurveOnS2: Standard_Boolean): void;
+  Approximation_2(): Standard_Boolean;
+  PCurveOnS1_2(): Standard_Boolean;
+  PCurveOnS2_2(): Standard_Boolean;
+  delete(): void;
+}
+
+  export declare class BOPAlgo_SectionAttribute_1 extends BOPAlgo_SectionAttribute {
+    constructor();
+  }
+
+  export declare class BOPAlgo_SectionAttribute_2 extends BOPAlgo_SectionAttribute {
+    constructor(theAproximation: Standard_Boolean, thePCurveOnS1: Standard_Boolean, thePCurveOnS2: Standard_Boolean);
+  }
+
+export declare class BOPAlgo_ArgumentAnalyzer extends BOPAlgo_Algo {
+  constructor()
+  SetShape1(TheShape: TopoDS_Shape): void;
+  SetShape2(TheShape: TopoDS_Shape): void;
+  GetShape1(): TopoDS_Shape;
+  GetShape2(): TopoDS_Shape;
+  OperationType(): BOPAlgo_Operation;
+  StopOnFirstFaulty(): Standard_Boolean;
+  ArgumentTypeMode(): Standard_Boolean;
+  SelfInterMode(): Standard_Boolean;
+  SmallEdgeMode(): Standard_Boolean;
+  RebuildFaceMode(): Standard_Boolean;
+  TangentMode(): Standard_Boolean;
+  MergeVertexMode(): Standard_Boolean;
+  MergeEdgeMode(): Standard_Boolean;
+  ContinuityMode(): Standard_Boolean;
+  CurveOnSurfaceMode(): Standard_Boolean;
+  Perform(theRange: Message_ProgressRange): void;
+  HasFaulty(): Standard_Boolean;
+  GetCheckResult(): BOPAlgo_ListOfCheckResult;
+  delete(): void;
+}
+
+export declare class BOPAlgo_BuilderFace extends BOPAlgo_BuilderArea {
+  SetFace(theFace: TopoDS_Face): void;
+  Face(): TopoDS_Face;
+  Perform(theRange: Message_ProgressRange): void;
+  Orientation(): TopAbs_Orientation;
+  delete(): void;
+}
+
+  export declare class BOPAlgo_BuilderFace_1 extends BOPAlgo_BuilderFace {
+    constructor();
+  }
+
+  export declare class BOPAlgo_BuilderFace_2 extends BOPAlgo_BuilderFace {
+    constructor(theAllocator: Handle_NCollection_BaseAllocator);
+  }
+
+export declare type BOPAlgo_CheckStatus = {
+  BOPAlgo_CheckUnknown: {};
+  BOPAlgo_BadType: {};
+  BOPAlgo_SelfIntersect: {};
+  BOPAlgo_TooSmallEdge: {};
+  BOPAlgo_NonRecoverableFace: {};
+  BOPAlgo_IncompatibilityOfVertex: {};
+  BOPAlgo_IncompatibilityOfEdge: {};
+  BOPAlgo_IncompatibilityOfFace: {};
+  BOPAlgo_OperationAborted: {};
+  BOPAlgo_GeomAbs_C0: {};
+  BOPAlgo_InvalidCurveOnSurface: {};
+  BOPAlgo_NotValid: {};
+}
+
+export declare class BOPAlgo_Builder extends BOPAlgo_BuilderShape {
+  Clear(): void;
+  PPaveFiller(): BOPAlgo_PPaveFiller;
+  PDS(): BOPDS_PDS;
+  Context(): Handle_IntTools_Context;
+  AddArgument(theShape: TopoDS_Shape): void;
+  SetArguments(theLS: TopTools_ListOfShape): void;
+  Arguments(): TopTools_ListOfShape;
+  SetNonDestructive(theFlag: Standard_Boolean): void;
+  NonDestructive(): Standard_Boolean;
+  SetGlue(theGlue: BOPAlgo_GlueEnum): void;
+  Glue(): BOPAlgo_GlueEnum;
+  SetCheckInverted(theCheck: Standard_Boolean): void;
+  CheckInverted(): Standard_Boolean;
+  Perform(theRange: Message_ProgressRange): void;
+  PerformWithFiller(theFiller: BOPAlgo_PaveFiller, theRange: Message_ProgressRange): void;
+  BuildBOP_1(theObjects: TopTools_ListOfShape, theObjState: TopAbs_State, theTools: TopTools_ListOfShape, theToolsState: TopAbs_State, theRange: Message_ProgressRange, theReport: Handle_Message_Report): void;
+  BuildBOP_2(theObjects: TopTools_ListOfShape, theTools: TopTools_ListOfShape, theOperation: BOPAlgo_Operation, theRange: Message_ProgressRange, theReport: Handle_Message_Report): void;
+  Images(): TopTools_DataMapOfShapeListOfShape;
+  Origins(): TopTools_DataMapOfShapeListOfShape;
+  ShapesSD(): TopTools_DataMapOfShapeShape;
+  delete(): void;
+}
+
+  export declare class BOPAlgo_Builder_1 extends BOPAlgo_Builder {
+    constructor();
+  }
+
+  export declare class BOPAlgo_Builder_2 extends BOPAlgo_Builder {
+    constructor(theAllocator: Handle_NCollection_BaseAllocator);
+  }
+
+export declare class BOPAlgo_Section extends BOPAlgo_Builder {
+  delete(): void;
+}
+
+  export declare class BOPAlgo_Section_1 extends BOPAlgo_Section {
+    constructor();
+  }
+
+  export declare class BOPAlgo_Section_2 extends BOPAlgo_Section {
+    constructor(theAllocator: Handle_NCollection_BaseAllocator);
+  }
+
+export declare class BOPAlgo_BuilderArea extends BOPAlgo_Algo {
+  SetContext(theContext: Handle_IntTools_Context): void;
+  Shapes(): TopTools_ListOfShape;
+  SetShapes(theLS: TopTools_ListOfShape): void;
+  Loops(): TopTools_ListOfShape;
+  Areas(): TopTools_ListOfShape;
+  SetAvoidInternalShapes(theAvoidInternal: Standard_Boolean): void;
+  IsAvoidInternalShapes(): Standard_Boolean;
+  delete(): void;
+}
+
+export declare class BOPAlgo_BuilderSolid extends BOPAlgo_BuilderArea {
+  Perform(theRange: Message_ProgressRange): void;
+  GetBoxesMap(): TopTools_DataMapOfShapeBox;
+  delete(): void;
+}
+
+  export declare class BOPAlgo_BuilderSolid_1 extends BOPAlgo_BuilderSolid {
+    constructor();
+  }
+
+  export declare class BOPAlgo_BuilderSolid_2 extends BOPAlgo_BuilderSolid {
+    constructor(theAllocator: Handle_NCollection_BaseAllocator);
+  }
+
+export declare class BOPAlgo_BuilderShape extends BOPAlgo_Algo {
+  Shape(): TopoDS_Shape;
+  Modified(theS: TopoDS_Shape): TopTools_ListOfShape;
+  Generated(theS: TopoDS_Shape): TopTools_ListOfShape;
+  IsDeleted(theS: TopoDS_Shape): Standard_Boolean;
+  HasModified(): Standard_Boolean;
+  HasGenerated(): Standard_Boolean;
+  HasDeleted(): Standard_Boolean;
+  History(): Handle_BRepTools_History;
+  SetToFillHistory(theHistFlag: Standard_Boolean): void;
+  HasHistory(): Standard_Boolean;
+  delete(): void;
+}
+
+export declare class BOPAlgo_CheckResult {
+  constructor()
+  SetShape1(TheShape: TopoDS_Shape): void;
+  AddFaultyShape1(TheShape: TopoDS_Shape): void;
+  SetShape2(TheShape: TopoDS_Shape): void;
+  AddFaultyShape2(TheShape: TopoDS_Shape): void;
+  GetShape1(): TopoDS_Shape;
+  GetShape2(): TopoDS_Shape;
+  GetFaultyShapes1(): TopTools_ListOfShape;
+  GetFaultyShapes2(): TopTools_ListOfShape;
+  SetCheckStatus(TheStatus: BOPAlgo_CheckStatus): void;
+  GetCheckStatus(): BOPAlgo_CheckStatus;
+  SetMaxDistance1(theDist: Standard_Real): void;
+  SetMaxDistance2(theDist: Standard_Real): void;
+  SetMaxParameter1(thePar: Standard_Real): void;
+  SetMaxParameter2(thePar: Standard_Real): void;
+  GetMaxDistance1(): Standard_Real;
+  GetMaxDistance2(): Standard_Real;
+  GetMaxParameter1(): Standard_Real;
+  GetMaxParameter2(): Standard_Real;
+  delete(): void;
+}
+
+export declare class BOPAlgo_MakerVolume extends BOPAlgo_Builder {
+  Clear(): void;
+  SetIntersect(bIntersect: Standard_Boolean): void;
+  IsIntersect(): Standard_Boolean;
+  Box(): TopoDS_Solid;
+  Faces(): TopTools_ListOfShape;
+  SetAvoidInternalShapes(theAvoidInternal: Standard_Boolean): void;
+  IsAvoidInternalShapes(): Standard_Boolean;
+  Perform(theRange: Message_ProgressRange): void;
+  delete(): void;
+}
+
+  export declare class BOPAlgo_MakerVolume_1 extends BOPAlgo_MakerVolume {
+    constructor();
+  }
+
+  export declare class BOPAlgo_MakerVolume_2 extends BOPAlgo_MakerVolume {
+    constructor(theAllocator: Handle_NCollection_BaseAllocator);
+  }
+
+export declare class BOPAlgo_ShellSplitter extends BOPAlgo_Algo {
+  AddStartElement(theS: TopoDS_Shape): void;
+  StartElements(): TopTools_ListOfShape;
+  Perform(theRange: Message_ProgressRange): void;
+  Shells(): TopTools_ListOfShape;
+  static SplitBlock(theCB: BOPTools_ConnexityBlock): void;
+  delete(): void;
+}
+
+  export declare class BOPAlgo_ShellSplitter_1 extends BOPAlgo_ShellSplitter {
+    constructor();
+  }
+
+  export declare class BOPAlgo_ShellSplitter_2 extends BOPAlgo_ShellSplitter {
+    constructor(theAllocator: Handle_NCollection_BaseAllocator);
+  }
+
+export declare type BOPAlgo_Operation = {
+  BOPAlgo_COMMON: {};
+  BOPAlgo_FUSE: {};
+  BOPAlgo_CUT: {};
+  BOPAlgo_CUT21: {};
+  BOPAlgo_SECTION: {};
+  BOPAlgo_UNKNOWN: {};
+}
+
+export declare class BOPAlgo_CellsBuilder extends BOPAlgo_Builder {
+  Clear(): void;
+  AddToResult(theLSToTake: TopTools_ListOfShape, theLSToAvoid: TopTools_ListOfShape, theMaterial: Graphic3d_ZLayerId, theUpdate: Standard_Boolean): void;
+  AddAllToResult(theMaterial: Graphic3d_ZLayerId, theUpdate: Standard_Boolean): void;
+  RemoveFromResult(theLSToTake: TopTools_ListOfShape, theLSToAvoid: TopTools_ListOfShape): void;
+  RemoveAllFromResult(): void;
+  RemoveInternalBoundaries(): void;
+  GetAllParts(): TopoDS_Shape;
+  MakeContainers(): void;
+  delete(): void;
+}
+
+  export declare class BOPAlgo_CellsBuilder_1 extends BOPAlgo_CellsBuilder {
+    constructor();
+  }
+
+  export declare class BOPAlgo_CellsBuilder_2 extends BOPAlgo_CellsBuilder {
+    constructor(theAllocator: Handle_NCollection_BaseAllocator);
+  }
+
+export declare class BOPAlgo_BOP extends BOPAlgo_ToolsProvider {
+  Clear(): void;
+  SetOperation(theOperation: BOPAlgo_Operation): void;
+  Operation(): BOPAlgo_Operation;
+  Perform(theRange: Message_ProgressRange): void;
+  delete(): void;
+}
+
+  export declare class BOPAlgo_BOP_1 extends BOPAlgo_BOP {
+    constructor();
+  }
+
+  export declare class BOPAlgo_BOP_2 extends BOPAlgo_BOP {
+    constructor(theAllocator: Handle_NCollection_BaseAllocator);
+  }
+
+export declare class BOPAlgo_CheckerSI extends BOPAlgo_PaveFiller {
+  constructor()
+  Perform(theRange: Message_ProgressRange): void;
+  SetLevelOfCheck(theLevel: Graphic3d_ZLayerId): void;
+  delete(): void;
+}
+
+export declare class BOPAlgo_Splitter extends BOPAlgo_ToolsProvider {
+  Perform(theRange: Message_ProgressRange): void;
+  delete(): void;
+}
+
+  export declare class BOPAlgo_Splitter_1 extends BOPAlgo_Splitter {
+    constructor();
+  }
+
+  export declare class BOPAlgo_Splitter_2 extends BOPAlgo_Splitter {
+    constructor(theAllocator: Handle_NCollection_BaseAllocator);
+  }
+
+export declare class BOPAlgo_Tools {
+  constructor();
+  static FillMap_2(thePB1: Handle_BOPDS_PaveBlock, theF: Graphic3d_ZLayerId, theMILI: BOPDS_IndexedDataMapOfPaveBlockListOfInteger, theAllocator: Handle_NCollection_BaseAllocator): void;
+  static ComputeToleranceOfCB(theCB: Handle_BOPDS_CommonBlock, theDS: BOPDS_PDS, theContext: Handle_IntTools_Context): Standard_Real;
+  static EdgesToWires(theEdges: TopoDS_Shape, theWires: TopoDS_Shape, theShared: Standard_Boolean, theAngTol: Standard_Real): Graphic3d_ZLayerId;
+  static WiresToFaces(theWires: TopoDS_Shape, theFaces: TopoDS_Shape, theAngTol: Standard_Real): Standard_Boolean;
+  static IntersectVertices(theVertices: TopTools_IndexedDataMapOfShapeReal, theFuzzyValue: Standard_Real, theChains: TopTools_ListOfListOfShape): void;
+  static ClassifyFaces(theFaces: TopTools_ListOfShape, theSolids: TopTools_ListOfShape, theRunParallel: Standard_Boolean, theContext: Handle_IntTools_Context, theInParts: TopTools_IndexedDataMapOfShapeListOfShape, theShapeBoxMap: TopTools_DataMapOfShapeBox, theSolidsIF: TopTools_DataMapOfShapeListOfShape, theRange: Message_ProgressRange): void;
+  static FillInternals(theSolids: TopTools_ListOfShape, theParts: TopTools_ListOfShape, theImages: TopTools_DataMapOfShapeListOfShape, theContext: Handle_IntTools_Context): void;
+  static TrsfToPoint(theBox1: Bnd_Box, theBox2: Bnd_Box, theTrsf: gp_Trsf, thePoint: gp_Pnt, theCriteria: Standard_Real): Standard_Boolean;
+  delete(): void;
+}
+
+export declare class BOPAlgo_Options {
+  Allocator(): Handle_NCollection_BaseAllocator;
+  Clear(): void;
+  AddError(theAlert: Handle_Message_Alert): void;
+  AddWarning(theAlert: Handle_Message_Alert): void;
+  HasErrors(): Standard_Boolean;
+  HasError(theType: Handle_Standard_Type): Standard_Boolean;
+  HasWarnings(): Standard_Boolean;
+  HasWarning(theType: Handle_Standard_Type): Standard_Boolean;
+  GetReport(): Handle_Message_Report;
+  DumpErrors(theOS: Standard_OStream): void;
+  DumpWarnings(theOS: Standard_OStream): void;
+  ClearWarnings(): void;
+  static GetParallelMode(): Standard_Boolean;
+  static SetParallelMode(theNewMode: Standard_Boolean): void;
+  SetRunParallel(theFlag: Standard_Boolean): void;
+  RunParallel(): Standard_Boolean;
+  SetFuzzyValue(theFuzz: Standard_Real): void;
+  FuzzyValue(): Standard_Real;
+  SetUseOBB(theUseOBB: Standard_Boolean): void;
+  UseOBB(): Standard_Boolean;
+  delete(): void;
+}
+
+  export declare class BOPAlgo_Options_1 extends BOPAlgo_Options {
+    constructor();
+  }
+
+  export declare class BOPAlgo_Options_2 extends BOPAlgo_Options {
+    constructor(theAllocator: Handle_NCollection_BaseAllocator);
+  }
+
 export declare type IFSelect_ReturnStatus = {
   IFSelect_RetVoid: {};
   IFSelect_RetDone: {};
@@ -8970,6 +9377,39 @@ export declare class BRepFeat_Form extends BRepBuilderAPI_MakeShape {
   delete(): void;
 }
 
+export declare class BRepFeat_Builder extends BOPAlgo_BOP {
+  constructor()
+  Clear(): void;
+  Init_1(theShape: TopoDS_Shape): void;
+  Init_2(theShape: TopoDS_Shape, theTool: TopoDS_Shape): void;
+  SetOperation_1(theFuse: Graphic3d_ZLayerId): void;
+  SetOperation_2(theFuse: Graphic3d_ZLayerId, theFlag: Standard_Boolean): void;
+  PartsOfTool(theLT: TopTools_ListOfShape): void;
+  KeepParts(theIm: TopTools_ListOfShape): void;
+  KeepPart(theS: TopoDS_Shape): void;
+  PerformResult(theRange: Message_ProgressRange): void;
+  RebuildFaces(): void;
+  RebuildEdge(theE: TopoDS_Shape, theF: TopoDS_Face, theME: TopTools_MapOfShape, aLEIm: TopTools_ListOfShape): void;
+  CheckSolidImages(): void;
+  FillRemoved_1(): void;
+  FillRemoved_2(theS: TopoDS_Shape, theM: TopTools_MapOfShape): void;
+  delete(): void;
+}
+
+export declare class BRepFeat_MakeCylindricalHole extends BRepFeat_Builder {
+  constructor()
+  Init_1(Axis: gp_Ax1): void;
+  Init_2(S: TopoDS_Shape, Axis: gp_Ax1): void;
+  Perform_1(Radius: Standard_Real): void;
+  Perform_2(Radius: Standard_Real, PFrom: Standard_Real, PTo: Standard_Real, WithControl: Standard_Boolean): void;
+  PerformThruNext(Radius: Standard_Real, WithControl: Standard_Boolean): void;
+  PerformUntilEnd(Radius: Standard_Real, WithControl: Standard_Boolean): void;
+  PerformBlind(Radius: Standard_Real, Length: Standard_Real, WithControl: Standard_Boolean): void;
+  Status(): BRepFeat_Status;
+  Build(): void;
+  delete(): void;
+}
+
 export declare class TNaming_NamedShape extends TDF_Attribute {
   constructor()
   static GetID(): Standard_GUID;
@@ -9774,6 +10214,7 @@ export declare class BitByBitDev {
   static ConvertAsciiString(s: XCAFDoc_PartId): string;
   static GetExceptionMessage(exceptionPtr: intptr_t): string;
   static BitSplit(shape: TopoDS_Shape, shapesToSplitWith: TopTools_ListOfShape): TopoDS_Shape;
+  static BitListOfShapesToCompound(shapesToSplitWith: TopTools_ListOfShape): TopoDS_Compound;
   delete(): void;
 }
 
@@ -10312,6 +10753,59 @@ export type OpenCascadeInstance = {FS: typeof FS} & {
   TColStd_IndexedDataMapOfStringString_1: typeof TColStd_IndexedDataMapOfStringString_1;
   TColStd_IndexedDataMapOfStringString_2: typeof TColStd_IndexedDataMapOfStringString_2;
   TColStd_IndexedDataMapOfStringString_3: typeof TColStd_IndexedDataMapOfStringString_3;
+  BOPAlgo_GlueEnum: BOPAlgo_GlueEnum;
+  BOPAlgo_Algo: typeof BOPAlgo_Algo;
+  BOPAlgo_WireEdgeSet: typeof BOPAlgo_WireEdgeSet;
+  BOPAlgo_WireEdgeSet_1: typeof BOPAlgo_WireEdgeSet_1;
+  BOPAlgo_WireEdgeSet_2: typeof BOPAlgo_WireEdgeSet_2;
+  BOPAlgo_WireSplitter: typeof BOPAlgo_WireSplitter;
+  BOPAlgo_WireSplitter_1: typeof BOPAlgo_WireSplitter_1;
+  BOPAlgo_WireSplitter_2: typeof BOPAlgo_WireSplitter_2;
+  BOPAlgo_ListOfCheckResult: typeof BOPAlgo_ListOfCheckResult;
+  BOPAlgo_ListOfCheckResult_1: typeof BOPAlgo_ListOfCheckResult_1;
+  BOPAlgo_ListOfCheckResult_2: typeof BOPAlgo_ListOfCheckResult_2;
+  BOPAlgo_ListOfCheckResult_3: typeof BOPAlgo_ListOfCheckResult_3;
+  BOPAlgo_SectionAttribute: typeof BOPAlgo_SectionAttribute;
+  BOPAlgo_SectionAttribute_1: typeof BOPAlgo_SectionAttribute_1;
+  BOPAlgo_SectionAttribute_2: typeof BOPAlgo_SectionAttribute_2;
+  BOPAlgo_ArgumentAnalyzer: typeof BOPAlgo_ArgumentAnalyzer;
+  BOPAlgo_BuilderFace: typeof BOPAlgo_BuilderFace;
+  BOPAlgo_BuilderFace_1: typeof BOPAlgo_BuilderFace_1;
+  BOPAlgo_BuilderFace_2: typeof BOPAlgo_BuilderFace_2;
+  BOPAlgo_CheckStatus: BOPAlgo_CheckStatus;
+  BOPAlgo_Builder: typeof BOPAlgo_Builder;
+  BOPAlgo_Builder_1: typeof BOPAlgo_Builder_1;
+  BOPAlgo_Builder_2: typeof BOPAlgo_Builder_2;
+  BOPAlgo_Section: typeof BOPAlgo_Section;
+  BOPAlgo_Section_1: typeof BOPAlgo_Section_1;
+  BOPAlgo_Section_2: typeof BOPAlgo_Section_2;
+  BOPAlgo_BuilderArea: typeof BOPAlgo_BuilderArea;
+  BOPAlgo_BuilderSolid: typeof BOPAlgo_BuilderSolid;
+  BOPAlgo_BuilderSolid_1: typeof BOPAlgo_BuilderSolid_1;
+  BOPAlgo_BuilderSolid_2: typeof BOPAlgo_BuilderSolid_2;
+  BOPAlgo_BuilderShape: typeof BOPAlgo_BuilderShape;
+  BOPAlgo_CheckResult: typeof BOPAlgo_CheckResult;
+  BOPAlgo_MakerVolume: typeof BOPAlgo_MakerVolume;
+  BOPAlgo_MakerVolume_1: typeof BOPAlgo_MakerVolume_1;
+  BOPAlgo_MakerVolume_2: typeof BOPAlgo_MakerVolume_2;
+  BOPAlgo_ShellSplitter: typeof BOPAlgo_ShellSplitter;
+  BOPAlgo_ShellSplitter_1: typeof BOPAlgo_ShellSplitter_1;
+  BOPAlgo_ShellSplitter_2: typeof BOPAlgo_ShellSplitter_2;
+  BOPAlgo_Operation: BOPAlgo_Operation;
+  BOPAlgo_CellsBuilder: typeof BOPAlgo_CellsBuilder;
+  BOPAlgo_CellsBuilder_1: typeof BOPAlgo_CellsBuilder_1;
+  BOPAlgo_CellsBuilder_2: typeof BOPAlgo_CellsBuilder_2;
+  BOPAlgo_BOP: typeof BOPAlgo_BOP;
+  BOPAlgo_BOP_1: typeof BOPAlgo_BOP_1;
+  BOPAlgo_BOP_2: typeof BOPAlgo_BOP_2;
+  BOPAlgo_CheckerSI: typeof BOPAlgo_CheckerSI;
+  BOPAlgo_Splitter: typeof BOPAlgo_Splitter;
+  BOPAlgo_Splitter_1: typeof BOPAlgo_Splitter_1;
+  BOPAlgo_Splitter_2: typeof BOPAlgo_Splitter_2;
+  BOPAlgo_Tools: typeof BOPAlgo_Tools;
+  BOPAlgo_Options: typeof BOPAlgo_Options;
+  BOPAlgo_Options_1: typeof BOPAlgo_Options_1;
+  BOPAlgo_Options_2: typeof BOPAlgo_Options_2;
   IFSelect_ReturnStatus: IFSelect_ReturnStatus;
   XCAFApp_Application: typeof XCAFApp_Application;
   Handle_XCAFApp_Application: typeof Handle_XCAFApp_Application;
@@ -10943,6 +11437,8 @@ export type OpenCascadeInstance = {FS: typeof FS} & {
   BRepFeat_MakeDPrism_1: typeof BRepFeat_MakeDPrism_1;
   BRepFeat_MakeDPrism_2: typeof BRepFeat_MakeDPrism_2;
   BRepFeat_Form: typeof BRepFeat_Form;
+  BRepFeat_Builder: typeof BRepFeat_Builder;
+  BRepFeat_MakeCylindricalHole: typeof BRepFeat_MakeCylindricalHole;
   TNaming_NamedShape: typeof TNaming_NamedShape;
   GeomPlate_CurveConstraint: typeof GeomPlate_CurveConstraint;
   GeomPlate_CurveConstraint_1: typeof GeomPlate_CurveConstraint_1;

--- a/packages/dev/occt/bitbybit-dev-occt/bitbybit-dev-occt.yml
+++ b/packages/dev/occt/bitbybit-dev-occt/bitbybit-dev-occt.yml
@@ -4,6 +4,30 @@
       - symbol: Adaptor3d_Curve
       - symbol: Adaptor3d_Surface
       - symbol: Approx_ParametrizationType
+      - symbol: BOPAlgo_Algo
+      - symbol: BOPAlgo_ArgumentAnalyzer
+      - symbol: BOPAlgo_BOP
+      - symbol: BOPAlgo_Builder
+      - symbol: BOPAlgo_BuilderArea
+      - symbol: BOPAlgo_BuilderFace
+      - symbol: BOPAlgo_BuilderShape
+      - symbol: BOPAlgo_BuilderSolid
+      - symbol: BOPAlgo_CellsBuilder
+      - symbol: BOPAlgo_CheckResult
+      - symbol: BOPAlgo_CheckStatus
+      - symbol: BOPAlgo_CheckerSI
+      - symbol: BOPAlgo_GlueEnum
+      - symbol: BOPAlgo_ListOfCheckResult
+      - symbol: BOPAlgo_MakerVolume
+      - symbol: BOPAlgo_Operation
+      - symbol: BOPAlgo_Options
+      - symbol: BOPAlgo_Section
+      - symbol: BOPAlgo_SectionAttribute
+      - symbol: BOPAlgo_ShellSplitter
+      - symbol: BOPAlgo_Splitter
+      - symbol: BOPAlgo_Tools
+      - symbol: BOPAlgo_WireEdgeSet
+      - symbol: BOPAlgo_WireSplitter
       - symbol: BRepAdaptor_CompCurve
       - symbol: BRepAdaptor_Curve
       - symbol: BRepAlgoAPI_Algo
@@ -53,7 +77,9 @@
       - symbol: BRepExtrema_SolutionElem
       - symbol: BRepExtrema_SupportType
       - symbol: BRepExtrema_TriangleSet
+      - symbol: BRepFeat_Builder
       - symbol: BRepFeat_Form
+      - symbol: BRepFeat_MakeCylindricalHole
       - symbol: BRepFeat_MakeDPrism
       - symbol: BRepFeat_SplitShape
       - symbol: BRepFill_Filling
@@ -352,6 +378,7 @@
     #include <BRepFeat_SplitShape.hxx>
     #include <TopTools_SequenceOfShape.hxx>
     #include <TopoDS_Shape.hxx>
+    #include <vector>
     
     typedef Handle(IMeshTools_Context) Handle_IMeshTools_Context;
     class BitByBitDev {
@@ -390,6 +417,22 @@
             splitShape.Add(shapesToSplitWithSequence);
             splitShape.Build();
             return splitShape.Shape();
+        }
+    public:
+        static TopoDS_Compound BitListOfShapesToCompound(const TopTools_ListOfShape& shapesToSplitWith) {
+            BRep_Builder builder;
+            TopoDS_Compound compound;
+            builder.MakeCompound(compound); // Initialize the compound shape
+
+            try {
+                for (TopTools_ListIteratorOfListOfShape it(shapesToSplitWith); it.More(); it.Next()) {
+                    builder.Add(compound, it.Value()); // Add each shape to the compound
+                }
+            } catch (...) {
+                return TopoDS_Compound(); // Return an empty compound on failure
+            }
+
+            return compound; // Return the resulting compound shape
         }
     };
     

--- a/packages/dev/occt/generate-prod-build-yaml.js
+++ b/packages/dev/occt/generate-prod-build-yaml.js
@@ -104,6 +104,30 @@ async function start() {
         "GeomPlate_PointConstraint",
         "BRepFill_Filling",
         "BRepFeat_SplitShape",
+        "BOPAlgo_Algo",
+        "BOPAlgo_ArgumentAnalyzer",
+        "BOPAlgo_BOP",
+        "BOPAlgo_Builder",
+        "BOPAlgo_BuilderArea",
+        "BOPAlgo_BuilderFace",
+        "BOPAlgo_BuilderShape",
+        "BOPAlgo_BuilderSolid",
+        "BOPAlgo_CellsBuilder",
+        "BOPAlgo_CheckResult",
+        "BOPAlgo_CheckStatus",
+        "BOPAlgo_CheckerSI",
+        "BOPAlgo_GlueEnum",
+        "BOPAlgo_ListOfCheckResult",
+        "BOPAlgo_MakerVolume",
+        "BOPAlgo_Operation",
+        "BOPAlgo_Options",
+        "BOPAlgo_Section",
+        "BOPAlgo_SectionAttribute",
+        "BOPAlgo_ShellSplitter",
+        "BOPAlgo_Splitter",
+        "BOPAlgo_Tools",
+        "BOPAlgo_WireEdgeSet",
+        "BOPAlgo_WireSplitter",
         "GeomLProp_SLProps",
         "gp",
         "gp_XYZ",
@@ -252,6 +276,8 @@ async function start() {
         "BRepClass_Edge",
         "BRepFeat_MakeDPrism",
         "BRepFeat_Form",
+        "BRepFeat_Builder",
+        "BRepFeat_MakeCylindricalHole",
         "ChFiDS_ChamfMode",
         "Extrema_ExtAlgo",
         "ShapeFix_Root",
@@ -484,6 +510,7 @@ async function start() {
     #include <BRepFeat_SplitShape.hxx>
     #include <TopTools_SequenceOfShape.hxx>
     #include <TopoDS_Shape.hxx>
+    #include <vector>
     
     typedef Handle(IMeshTools_Context) Handle_IMeshTools_Context;
     class BitByBitDev {
@@ -522,6 +549,22 @@ async function start() {
             splitShape.Add(shapesToSplitWithSequence);
             splitShape.Build();
             return splitShape.Shape();
+        }
+    public:
+        static TopoDS_Compound BitListOfShapesToCompound(const TopTools_ListOfShape& shapesToSplitWith) {
+            BRep_Builder builder;
+            TopoDS_Compound compound;
+            builder.MakeCompound(compound); // Initialize the compound shape
+
+            try {
+                for (TopTools_ListIteratorOfListOfShape it(shapesToSplitWith); it.More(); it.Next()) {
+                    builder.Add(compound, it.Value()); // Add each shape to the compound
+                }
+            } catch (...) {
+                return TopoDS_Compound(); // Return an empty compound on failure
+            }
+
+            return compound; // Return the resulting compound shape
         }
     };
     `;

--- a/packages/dev/occt/lib/api/inputs/occ-inputs.ts
+++ b/packages/dev/occt/lib/api/inputs/occ-inputs.ts
@@ -3554,6 +3554,19 @@ export namespace OCCT {
          * @default undefined
          */
         shapes: T[];
+        /**
+         * Local fuzzy tolerance used for splitting
+         * @default 1.0e-4
+         * @minimum 0
+         * @maximum Infinity
+         * @step 0.000001
+         */
+        localFuzzyTolerance = 1.0e-4;
+        /**
+         * Set to true if you want to split the shape non-destructively
+         * @default true
+         */
+        nonDestructive = true;
     }
     export class UnionDto<T> {
         constructor(shapes?: T[], keepEdges?: boolean) {

--- a/packages/dev/occt/lib/services/base/iterator.service.ts
+++ b/packages/dev/occt/lib/services/base/iterator.service.ts
@@ -125,4 +125,40 @@ export class IteratorService {
         anExplorer.delete();
     }
 
+    forEachCompound(shape: TopoDS_Shape, callback: (index: number, shape: TopoDS_Shape) => void): void {
+        let solidIndex = 0;
+        const anExplorer = new this.occ.TopExp_Explorer_2(shape,
+            (this.occ.TopAbs_ShapeEnum.TopAbs_COMPOUND as TopAbs_ShapeEnum),
+            (this.occ.TopAbs_ShapeEnum.TopAbs_SHAPE as TopAbs_ShapeEnum));
+        for (anExplorer.Init(shape,
+            (this.occ.TopAbs_ShapeEnum.TopAbs_COMPOUND as TopAbs_ShapeEnum),
+            (this.occ.TopAbs_ShapeEnum.TopAbs_SHAPE as TopAbs_ShapeEnum)); anExplorer.More(); anExplorer.Next()) {
+            callback(solidIndex++, anExplorer.Current());
+        }
+        anExplorer.delete();
+    }
+
+    forEachCompSolid(shape: TopoDS_Shape, callback: (index: number, shape: TopoDS_Shape) => void): void {
+        let solidIndex = 0;
+        const anExplorer = new this.occ.TopExp_Explorer_2(shape,
+            (this.occ.TopAbs_ShapeEnum.TopAbs_COMPSOLID as TopAbs_ShapeEnum),
+            (this.occ.TopAbs_ShapeEnum.TopAbs_SHAPE as TopAbs_ShapeEnum));
+        for (anExplorer.Init(shape,
+            (this.occ.TopAbs_ShapeEnum.TopAbs_COMPSOLID as TopAbs_ShapeEnum),
+            (this.occ.TopAbs_ShapeEnum.TopAbs_SHAPE as TopAbs_ShapeEnum)); anExplorer.More(); anExplorer.Next()) {
+            callback(solidIndex++, anExplorer.Current());
+        }
+        anExplorer.delete();
+    }
+    
+    forEachShapeInCompound(shape: TopoDS_Shape, callback: (index: number, shape: TopoDS_Shape) => void): void {
+        let solidIndex = 0;
+        const iterator = new this.occ.TopoDS_Iterator_1();
+    
+        for (iterator.Initialize(shape, true, true); iterator.More(); iterator.Next()) {
+            callback(solidIndex++, iterator.Value());
+        }
+        iterator.delete();
+    }
+
 }

--- a/packages/dev/occt/lib/services/base/shape-getters.ts
+++ b/packages/dev/occt/lib/services/base/shape-getters.ts
@@ -1,6 +1,6 @@
 import {
     OpenCascadeInstance, TopoDS_Edge, TopoDS_Face,
-    TopoDS_Shape, TopoDS_Solid, TopoDS_Vertex, TopoDS_Wire
+    TopoDS_Shape, TopoDS_Solid, TopoDS_Vertex, TopoDS_Wire, TopoDS_Compound
 } from "../../../bitbybit-dev-occt/bitbybit-dev-occt";
 import * as Inputs from "../../api/inputs/inputs";
 import { EnumService } from "./enum.service";
@@ -167,6 +167,12 @@ export class ShapeGettersService {
             vertices.push(vertex);
         });
         return vertices;
+    }
+
+    getShapesOfCompound(inputs: Inputs.OCCT.ShapeDto<TopoDS_Compound>): TopoDS_Shape[] {
+        const shapes: TopoDS_Shape[] = [];
+        this.iteratorService.forEachShapeInCompound(inputs.shape, (_, shape) => { shapes.push(shape); });
+        return shapes;
     }
 
 }

--- a/packages/dev/occt/lib/services/shapes/compound.ts
+++ b/packages/dev/occt/lib/services/shapes/compound.ts
@@ -14,4 +14,8 @@ export class OCCTCompound {
         return this.och.converterService.makeCompound(inputs);
     }
 
+    getShapesOfCompound(inputs: Inputs.OCCT.ShapeDto<TopoDS_Compound>): TopoDS_Shape[] {
+        return this.och.shapeGettersService.getShapesOfCompound(inputs);
+    }
+
 }

--- a/packages/dev/occt/package-lock.json
+++ b/packages/dev/occt/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@bitbybit-dev/occt",
-    "version": "0.19.2",
+    "version": "0.19.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@bitbybit-dev/occt",
-            "version": "0.19.2",
+            "version": "0.19.3",
             "license": "MIT",
             "devDependencies": {
                 "@babel/core": "7.16.0",

--- a/packages/dev/occt/package.json
+++ b/packages/dev/occt/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bitbybit-dev/occt",
-    "version": "0.19.2",
+    "version": "0.19.3",
     "description": "Bit By Bit Developers CAD algorithms using OpenCascade Technology kernel. Run in Node and in Browser.",
     "main": "index.js",
     "repository": {

--- a/packages/dev/threejs/package-lock.json
+++ b/packages/dev/threejs/package-lock.json
@@ -1,16 +1,16 @@
 {
     "name": "@bitbybit-dev/threejs",
-    "version": "0.19.2",
+    "version": "0.19.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@bitbybit-dev/threejs",
-            "version": "0.19.2",
+            "version": "0.19.3",
             "license": "MIT",
             "dependencies": {
-                "@bitbybit-dev/core": "0.19.2",
-                "three": "0.172.0"
+                "@bitbybit-dev/core": "0.19.3",
+                "three": "0.173.0"
             },
             "devDependencies": {
                 "@babel/core": "7.16.0",
@@ -18,7 +18,7 @@
                 "@babel/preset-typescript": "7.16.0",
                 "@testing-library/jest-dom": "5.14.1",
                 "@types/jest": "29.0.0",
-                "@types/three": "0.172.0",
+                "@types/three": "0.173.0",
                 "babel-jest": "29.0.0",
                 "jest": "29.4.1",
                 "jest-html-reporters": "3.0.11",
@@ -1703,30 +1703,30 @@
             "dev": true
         },
         "node_modules/@bitbybit-dev/base": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/base/-/base-0.19.2.tgz",
-            "integrity": "sha512-1fkGHec+ZtW5tfI6qPcy3sgkaWrYtL0Jy6nicJxKH21HCsCrCaQRq2yCU3vijBMMlyvImMo56uM0sbZRCTUpLQ=="
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/base/-/base-0.19.3.tgz",
+            "integrity": "sha512-5ALYrKg/8nD4c03yOuFTfaM0gTBq5IUFui8+6fUwE5HpZZy9NrKl9fo5tueELS5wHaXII2N7fCOEh6TxS0fpyQ=="
         },
         "node_modules/@bitbybit-dev/core": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/core/-/core-0.19.2.tgz",
-            "integrity": "sha512-zIw3RJhXwkKWAbeea7M9GQ+gDpauZzeAJNvapkG9H86JX4ng+u6dtoLkcaPBIKc3XWV7T7OG7VnzZCTJoG7wCA==",
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/core/-/core-0.19.3.tgz",
+            "integrity": "sha512-g4RwIALLxeg4YgKtlLmy+3dND7rjnCJ27iQj098AF8ICNohOtsULaNaTN5bxr4sSF3DbGVIoEu5h5vbbF/WWKQ==",
             "dependencies": {
-                "@bitbybit-dev/base": "0.19.2",
-                "@bitbybit-dev/jscad-worker": "0.19.2",
-                "@bitbybit-dev/manifold-worker": "0.19.2",
-                "@bitbybit-dev/occt-worker": "0.19.2",
+                "@bitbybit-dev/base": "0.19.3",
+                "@bitbybit-dev/jscad-worker": "0.19.3",
+                "@bitbybit-dev/manifold-worker": "0.19.3",
+                "@bitbybit-dev/occt-worker": "0.19.3",
                 "jsonpath-plus": "10.1.0",
                 "rxjs": "7.5.5",
                 "verb-nurbs-web": "2.1.3"
             }
         },
         "node_modules/@bitbybit-dev/jscad": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/jscad/-/jscad-0.19.2.tgz",
-            "integrity": "sha512-KHGY7W5NvkxAxvmN8XVZHq5EtC3W+OnRruDptBZvenNhQKZGkDQsuNjKfVhM6zWfoW31WV3C/Y6m090i8UWjlw==",
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/jscad/-/jscad-0.19.3.tgz",
+            "integrity": "sha512-x8jDMLPkPp98vw3Nwwawk19imcdq4QRsTXUjJieYzqVfN/0MslI+zZeoRmjRTUnYW+SpfLPfBpTKehbfJnF5yQ==",
             "dependencies": {
-                "@bitbybit-dev/base": "0.19.2",
+                "@bitbybit-dev/base": "0.19.3",
                 "@jscad/3mf-serializer": "2.1.12",
                 "@jscad/dxf-serializer": "2.1.18",
                 "@jscad/io-utils": "2.0.28",
@@ -1735,42 +1735,42 @@
             }
         },
         "node_modules/@bitbybit-dev/jscad-worker": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/jscad-worker/-/jscad-worker-0.19.2.tgz",
-            "integrity": "sha512-W66JixkiKqkpLS1Ile7tne01C68gfpbgJTvIYQMr/6jddxgA/MB7KpsSaqPyI6s7UVQgt6I/t9pmIJY1ijHAlQ==",
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/jscad-worker/-/jscad-worker-0.19.3.tgz",
+            "integrity": "sha512-UIc56Odk9FxJBjnJfc3Cd4lr/NzP846G59tGVql+pHqJ5xw9Dl1rHHDqy9n2JjGksDx/0i0q0hLWltywrSzdWQ==",
             "dependencies": {
-                "@bitbybit-dev/jscad": "0.19.2",
+                "@bitbybit-dev/jscad": "0.19.3",
                 "rxjs": "7.5.5"
             }
         },
         "node_modules/@bitbybit-dev/manifold": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/manifold/-/manifold-0.19.2.tgz",
-            "integrity": "sha512-7RzEOhmiEb8Mou+eRHft7+jWsNnXm0nIHWcMFvRtDfDrCF79dcBae3T175ZXBF2vDZP24rfcaeUyz35vH1qwCQ==",
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/manifold/-/manifold-0.19.3.tgz",
+            "integrity": "sha512-8FEUjwpJ0+QgzNCrzT3x2AYWsiDey2B8Nvx0uMa+s3xL3V1LGoCV+VBqk/aTwfzmTeOanI2MmUZuB7amUTWnHw==",
             "dependencies": {
                 "manifold-3d": "3.0.0"
             }
         },
         "node_modules/@bitbybit-dev/manifold-worker": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/manifold-worker/-/manifold-worker-0.19.2.tgz",
-            "integrity": "sha512-+Zi48ne6av+/Nj8KDXWYIjEHE/v8XMqVEzOq4cjayILLQ775/sxk/GA3KQ+q/wvq889n9jpMQPGk0shl+do6gQ==",
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/manifold-worker/-/manifold-worker-0.19.3.tgz",
+            "integrity": "sha512-7yDRnSTP1dv6k1Gk00HoBAIW8KwV3SDGDVOLT348+flrUMMU3X5EGhEgGHbBISLn/rzahfg0CFYxcHenB5HpOw==",
             "dependencies": {
-                "@bitbybit-dev/manifold": "0.19.2",
+                "@bitbybit-dev/manifold": "0.19.3",
                 "rxjs": "7.5.5"
             }
         },
         "node_modules/@bitbybit-dev/occt": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/occt/-/occt-0.19.2.tgz",
-            "integrity": "sha512-cn1YxdNnblWciusePkRo+TRE64rfrtqJFiP4MscoM1WSS7A7kgcUJlnX4Xam3ktPHtOWIE+3grahXTT5ndeTSQ=="
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/occt/-/occt-0.19.3.tgz",
+            "integrity": "sha512-pfXnidWliHshGeyft4EdkFwulRsqKqBZrrk4xAy11XaYZsL3xyHmTxj220t6CjCZ9SB5037NprDd9EQOHuTIKw=="
         },
         "node_modules/@bitbybit-dev/occt-worker": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/occt-worker/-/occt-worker-0.19.2.tgz",
-            "integrity": "sha512-QAd/P9hahotAmsG2ipQTo9m70y5l/aoD5HrdgXXkvaMMtHpMcMAHe10WHexWbTsJBdzCbecH7ukG1OJYfGoTEw==",
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/occt-worker/-/occt-worker-0.19.3.tgz",
+            "integrity": "sha512-usJ0f3WBUvBJ4F24J/8ZtXrxGxMyTbVaGz0x4zhRLfJmrHv/7I+M4y8qdSL+Zpe2jxecHxel+fno521t5vpCQQ==",
             "dependencies": {
-                "@bitbybit-dev/occt": "0.19.2",
+                "@bitbybit-dev/occt": "0.19.3",
                 "rxjs": "7.5.5"
             }
         },
@@ -2830,9 +2830,9 @@
             }
         },
         "node_modules/@types/three": {
-            "version": "0.172.0",
-            "resolved": "https://registry.npmjs.org/@types/three/-/three-0.172.0.tgz",
-            "integrity": "sha512-LrUtP3FEG26Zg5WiF0nbg8VoXiKokBLTcqM2iLvM9vzcfEiYmmBAPGdBgV0OYx9fvWlY3R/3ERTZcD9X5sc0NA==",
+            "version": "0.173.0",
+            "resolved": "https://registry.npmjs.org/@types/three/-/three-0.173.0.tgz",
+            "integrity": "sha512-KtNjfI/CRB6JVKIVeZM1R3GYDX2wkoV2itNcQu2j4d7qkhjGOuB+s2oF6jl9mztycDLGMtrAnJQYxInC8Bb20A==",
             "dev": true,
             "dependencies": {
                 "@tweenjs/tween.js": "~23.1.3",
@@ -6814,9 +6814,9 @@
             }
         },
         "node_modules/three": {
-            "version": "0.172.0",
-            "resolved": "https://registry.npmjs.org/three/-/three-0.172.0.tgz",
-            "integrity": "sha512-6HMgMlzU97MsV7D/tY8Va38b83kz8YJX+BefKjspMNAv0Vx6dxMogHOrnRl/sbMIs3BPUKijPqDqJ/+UwJbIow=="
+            "version": "0.173.0",
+            "resolved": "https://registry.npmjs.org/three/-/three-0.173.0.tgz",
+            "integrity": "sha512-AUwVmViIEUgBwxJJ7stnF0NkPpZxx1aZ6WiAbQ/Qq61h6I9UR4grXtZDmO8mnlaNORhHnIBlXJ1uBxILEKuVyw=="
         },
         "node_modules/tmpl": {
             "version": "1.0.5",
@@ -8441,30 +8441,30 @@
             "dev": true
         },
         "@bitbybit-dev/base": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/base/-/base-0.19.2.tgz",
-            "integrity": "sha512-1fkGHec+ZtW5tfI6qPcy3sgkaWrYtL0Jy6nicJxKH21HCsCrCaQRq2yCU3vijBMMlyvImMo56uM0sbZRCTUpLQ=="
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/base/-/base-0.19.3.tgz",
+            "integrity": "sha512-5ALYrKg/8nD4c03yOuFTfaM0gTBq5IUFui8+6fUwE5HpZZy9NrKl9fo5tueELS5wHaXII2N7fCOEh6TxS0fpyQ=="
         },
         "@bitbybit-dev/core": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/core/-/core-0.19.2.tgz",
-            "integrity": "sha512-zIw3RJhXwkKWAbeea7M9GQ+gDpauZzeAJNvapkG9H86JX4ng+u6dtoLkcaPBIKc3XWV7T7OG7VnzZCTJoG7wCA==",
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/core/-/core-0.19.3.tgz",
+            "integrity": "sha512-g4RwIALLxeg4YgKtlLmy+3dND7rjnCJ27iQj098AF8ICNohOtsULaNaTN5bxr4sSF3DbGVIoEu5h5vbbF/WWKQ==",
             "requires": {
-                "@bitbybit-dev/base": "0.19.2",
-                "@bitbybit-dev/jscad-worker": "0.19.2",
-                "@bitbybit-dev/manifold-worker": "0.19.2",
-                "@bitbybit-dev/occt-worker": "0.19.2",
+                "@bitbybit-dev/base": "0.19.3",
+                "@bitbybit-dev/jscad-worker": "0.19.3",
+                "@bitbybit-dev/manifold-worker": "0.19.3",
+                "@bitbybit-dev/occt-worker": "0.19.3",
                 "jsonpath-plus": "10.1.0",
                 "rxjs": "7.5.5",
                 "verb-nurbs-web": "2.1.3"
             }
         },
         "@bitbybit-dev/jscad": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/jscad/-/jscad-0.19.2.tgz",
-            "integrity": "sha512-KHGY7W5NvkxAxvmN8XVZHq5EtC3W+OnRruDptBZvenNhQKZGkDQsuNjKfVhM6zWfoW31WV3C/Y6m090i8UWjlw==",
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/jscad/-/jscad-0.19.3.tgz",
+            "integrity": "sha512-x8jDMLPkPp98vw3Nwwawk19imcdq4QRsTXUjJieYzqVfN/0MslI+zZeoRmjRTUnYW+SpfLPfBpTKehbfJnF5yQ==",
             "requires": {
-                "@bitbybit-dev/base": "0.19.2",
+                "@bitbybit-dev/base": "0.19.3",
                 "@jscad/3mf-serializer": "2.1.12",
                 "@jscad/dxf-serializer": "2.1.18",
                 "@jscad/io-utils": "2.0.28",
@@ -8473,42 +8473,42 @@
             }
         },
         "@bitbybit-dev/jscad-worker": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/jscad-worker/-/jscad-worker-0.19.2.tgz",
-            "integrity": "sha512-W66JixkiKqkpLS1Ile7tne01C68gfpbgJTvIYQMr/6jddxgA/MB7KpsSaqPyI6s7UVQgt6I/t9pmIJY1ijHAlQ==",
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/jscad-worker/-/jscad-worker-0.19.3.tgz",
+            "integrity": "sha512-UIc56Odk9FxJBjnJfc3Cd4lr/NzP846G59tGVql+pHqJ5xw9Dl1rHHDqy9n2JjGksDx/0i0q0hLWltywrSzdWQ==",
             "requires": {
-                "@bitbybit-dev/jscad": "0.19.2",
+                "@bitbybit-dev/jscad": "0.19.3",
                 "rxjs": "7.5.5"
             }
         },
         "@bitbybit-dev/manifold": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/manifold/-/manifold-0.19.2.tgz",
-            "integrity": "sha512-7RzEOhmiEb8Mou+eRHft7+jWsNnXm0nIHWcMFvRtDfDrCF79dcBae3T175ZXBF2vDZP24rfcaeUyz35vH1qwCQ==",
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/manifold/-/manifold-0.19.3.tgz",
+            "integrity": "sha512-8FEUjwpJ0+QgzNCrzT3x2AYWsiDey2B8Nvx0uMa+s3xL3V1LGoCV+VBqk/aTwfzmTeOanI2MmUZuB7amUTWnHw==",
             "requires": {
                 "manifold-3d": "3.0.0"
             }
         },
         "@bitbybit-dev/manifold-worker": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/manifold-worker/-/manifold-worker-0.19.2.tgz",
-            "integrity": "sha512-+Zi48ne6av+/Nj8KDXWYIjEHE/v8XMqVEzOq4cjayILLQ775/sxk/GA3KQ+q/wvq889n9jpMQPGk0shl+do6gQ==",
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/manifold-worker/-/manifold-worker-0.19.3.tgz",
+            "integrity": "sha512-7yDRnSTP1dv6k1Gk00HoBAIW8KwV3SDGDVOLT348+flrUMMU3X5EGhEgGHbBISLn/rzahfg0CFYxcHenB5HpOw==",
             "requires": {
-                "@bitbybit-dev/manifold": "0.19.2",
+                "@bitbybit-dev/manifold": "0.19.3",
                 "rxjs": "7.5.5"
             }
         },
         "@bitbybit-dev/occt": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/occt/-/occt-0.19.2.tgz",
-            "integrity": "sha512-cn1YxdNnblWciusePkRo+TRE64rfrtqJFiP4MscoM1WSS7A7kgcUJlnX4Xam3ktPHtOWIE+3grahXTT5ndeTSQ=="
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/occt/-/occt-0.19.3.tgz",
+            "integrity": "sha512-pfXnidWliHshGeyft4EdkFwulRsqKqBZrrk4xAy11XaYZsL3xyHmTxj220t6CjCZ9SB5037NprDd9EQOHuTIKw=="
         },
         "@bitbybit-dev/occt-worker": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/occt-worker/-/occt-worker-0.19.2.tgz",
-            "integrity": "sha512-QAd/P9hahotAmsG2ipQTo9m70y5l/aoD5HrdgXXkvaMMtHpMcMAHe10WHexWbTsJBdzCbecH7ukG1OJYfGoTEw==",
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/occt-worker/-/occt-worker-0.19.3.tgz",
+            "integrity": "sha512-usJ0f3WBUvBJ4F24J/8ZtXrxGxMyTbVaGz0x4zhRLfJmrHv/7I+M4y8qdSL+Zpe2jxecHxel+fno521t5vpCQQ==",
             "requires": {
-                "@bitbybit-dev/occt": "0.19.2",
+                "@bitbybit-dev/occt": "0.19.3",
                 "rxjs": "7.5.5"
             }
         },
@@ -9368,9 +9368,9 @@
             }
         },
         "@types/three": {
-            "version": "0.172.0",
-            "resolved": "https://registry.npmjs.org/@types/three/-/three-0.172.0.tgz",
-            "integrity": "sha512-LrUtP3FEG26Zg5WiF0nbg8VoXiKokBLTcqM2iLvM9vzcfEiYmmBAPGdBgV0OYx9fvWlY3R/3ERTZcD9X5sc0NA==",
+            "version": "0.173.0",
+            "resolved": "https://registry.npmjs.org/@types/three/-/three-0.173.0.tgz",
+            "integrity": "sha512-KtNjfI/CRB6JVKIVeZM1R3GYDX2wkoV2itNcQu2j4d7qkhjGOuB+s2oF6jl9mztycDLGMtrAnJQYxInC8Bb20A==",
             "dev": true,
             "requires": {
                 "@tweenjs/tween.js": "~23.1.3",
@@ -12353,9 +12353,9 @@
             }
         },
         "three": {
-            "version": "0.172.0",
-            "resolved": "https://registry.npmjs.org/three/-/three-0.172.0.tgz",
-            "integrity": "sha512-6HMgMlzU97MsV7D/tY8Va38b83kz8YJX+BefKjspMNAv0Vx6dxMogHOrnRl/sbMIs3BPUKijPqDqJ/+UwJbIow=="
+            "version": "0.173.0",
+            "resolved": "https://registry.npmjs.org/three/-/three-0.173.0.tgz",
+            "integrity": "sha512-AUwVmViIEUgBwxJJ7stnF0NkPpZxx1aZ6WiAbQ/Qq61h6I9UR4grXtZDmO8mnlaNORhHnIBlXJ1uBxILEKuVyw=="
         },
         "tmpl": {
             "version": "1.0.5",

--- a/packages/dev/threejs/package.json
+++ b/packages/dev/threejs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bitbybit-dev/threejs",
-    "version": "0.19.2",
+    "version": "0.19.3",
     "description": "Bit By Bit Developers THREEJS CAD Library to Program Geometry",
     "main": "index.js",
     "repository": {
@@ -54,8 +54,8 @@
     "types": "./index.d.ts",
     "type": "module",
     "dependencies": {
-        "three": "0.172.0",
-        "@bitbybit-dev/core": "0.19.2"
+        "three": "0.173.0",
+        "@bitbybit-dev/core": "0.19.3"
     },
     "devDependencies": {
         "sass": "1.57.1",
@@ -66,7 +66,7 @@
         "ts-jest": "29.0.0",
         "typescript": "4.8.2",
         "@types/jest": "29.0.0",
-        "@types/three": "0.172.0",
+        "@types/three": "0.173.0",
         "babel-jest": "29.0.0",
         "@babel/core": "7.16.0",
         "@babel/preset-env": "7.16.0",


### PR DESCRIPTION
- Split OCCT shape with other shapes by using new BOPAlgo_Builder methods
- Decompose OCCT compound shape to constituent parts
- Greased lines now use PBR materials, as it's easier to update colours
- update to BABYLONJS v7.47.2
- update to THREEJS v0.173.0