### PR TITLE
v0.19.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "bitbybit",
-    "version": "0.19.6",
+    "version": "0.19.7",
     "description": "Monorepo for browser CAD which holds bitbybit.dev npm packages",
     "main": "index.js",
     "scripts": {

--- a/packages/dev/babylonjs/lib/api/bitbybit/babylon/scene.ts
+++ b/packages/dev/babylonjs/lib/api/bitbybit/babylon/scene.ts
@@ -335,14 +335,14 @@ export class BabylonScene {
     enableSkybox(inputs: Inputs.BabylonScene.SkyboxDto): void {
         let texture: BABYLON.CubeTexture;
         if (inputs.skybox === Inputs.Base.skyboxEnum.default) {
-            texture = new BABYLON.CubeTexture("https://cdn.jsdelivr.net/gh/bitbybit-dev/bitbybit-assets@0.19.6/textures/skybox/default_skybox/skybox", this.context.scene);
+            texture = new BABYLON.CubeTexture("https://cdn.jsdelivr.net/gh/bitbybit-dev/bitbybit-assets@0.19.7/textures/skybox/default_skybox/skybox", this.context.scene);
         } else if (inputs.skybox === Inputs.Base.skyboxEnum.greyGradient) {
-            texture = new BABYLON.CubeTexture("https://cdn.jsdelivr.net/gh/bitbybit-dev/bitbybit-assets@0.19.6/textures/skybox/grey_gradient/skybox", this.context.scene);
+            texture = new BABYLON.CubeTexture("https://cdn.jsdelivr.net/gh/bitbybit-dev/bitbybit-assets@0.19.7/textures/skybox/grey_gradient/skybox", this.context.scene);
         } else if (inputs.skybox === Inputs.Base.skyboxEnum.clearSky) {
-            texture = BABYLON.CubeTexture.CreateFromPrefilteredData("https://cdn.jsdelivr.net/gh/bitbybit-dev/bitbybit-assets@0.19.6/textures/skybox/clear_sky/environment.env",
+            texture = BABYLON.CubeTexture.CreateFromPrefilteredData("https://cdn.jsdelivr.net/gh/bitbybit-dev/bitbybit-assets@0.19.7/textures/skybox/clear_sky/environment.env",
                 this.context.scene, false, false);
         } else if (inputs.skybox === Inputs.Base.skyboxEnum.city) {
-            texture = BABYLON.CubeTexture.CreateFromPrefilteredData("https://cdn.jsdelivr.net/gh/bitbybit-dev/bitbybit-assets@0.19.6/textures/skybox/city/environmentSpecular.env",
+            texture = BABYLON.CubeTexture.CreateFromPrefilteredData("https://cdn.jsdelivr.net/gh/bitbybit-dev/bitbybit-assets@0.19.7/textures/skybox/city/environmentSpecular.env",
                 this.context.scene, false, false);
         }
 

--- a/packages/dev/babylonjs/package-lock.json
+++ b/packages/dev/babylonjs/package-lock.json
@@ -1,21 +1,21 @@
 {
     "name": "@bitbybit-dev/babylonjs",
-    "version": "0.19.6",
+    "version": "0.19.7",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@bitbybit-dev/babylonjs",
-            "version": "0.19.6",
+            "version": "0.19.7",
             "license": "MIT",
             "dependencies": {
-                "@babylonjs/core": "7.52.1",
-                "@babylonjs/gui": "7.52.1",
+                "@babylonjs/core": "7.53.3",
+                "@babylonjs/gui": "7.53.3",
                 "@babylonjs/havok": "1.3.10",
-                "@babylonjs/loaders": "7.52.1",
-                "@babylonjs/materials": "7.52.1",
-                "@babylonjs/serializers": "7.52.1",
-                "@bitbybit-dev/core": "0.19.6",
+                "@babylonjs/loaders": "7.53.3",
+                "@babylonjs/materials": "7.53.3",
+                "@babylonjs/serializers": "7.53.3",
+                "@bitbybit-dev/core": "0.19.7",
                 "earcut": "2.2.3"
             },
             "devDependencies": {
@@ -1702,14 +1702,14 @@
             }
         },
         "node_modules/@babylonjs/core": {
-            "version": "7.52.1",
-            "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-7.52.1.tgz",
-            "integrity": "sha512-8lRbCoBJ15JRf86F2bAmkVwA+QYKtuaieuBU4FjAHZIDrWuY+/iYMRm7XjXB/zlYaZPln3zBYn+0K3YWYMrxWA=="
+            "version": "7.53.3",
+            "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-7.53.3.tgz",
+            "integrity": "sha512-clM03775eJ1X/kacTIZNji/1D2XMNQy57jTWGaUWDDlzDQoBeOpbIjhANfSeEsgeEM02diXrCkrfpMOcUHx2Ag=="
         },
         "node_modules/@babylonjs/gui": {
-            "version": "7.52.1",
-            "resolved": "https://registry.npmjs.org/@babylonjs/gui/-/gui-7.52.1.tgz",
-            "integrity": "sha512-MAylZzvdJnVlMtvimNSbd7MovcwnGoKBLiR9z+6FHMweagxfp03xomyvngB5F4GSq8JrTvfMcI1H8LGCkyNo8w==",
+            "version": "7.53.3",
+            "resolved": "https://registry.npmjs.org/@babylonjs/gui/-/gui-7.53.3.tgz",
+            "integrity": "sha512-qH/eoX8QI7tvdKctiI5ody8sFgDDrtElYa0lDwAhSx4UqkqRlBTHUwfALz4SBAA39xh0kubaKqWsPbLflCNjGA==",
             "peerDependencies": {
                 "@babylonjs/core": "^7.0.0"
             }
@@ -1723,26 +1723,26 @@
             }
         },
         "node_modules/@babylonjs/loaders": {
-            "version": "7.52.1",
-            "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-7.52.1.tgz",
-            "integrity": "sha512-h9hiDXt4YTBlrxBspmXM1C89B3otLVUs1P1MrEXIH2+YRN/zUAns+t8oG20Nag1tcmuMSGDkJ+3K+64v0/0+Bw==",
+            "version": "7.53.3",
+            "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-7.53.3.tgz",
+            "integrity": "sha512-NtrubMAQ+3kEqEVNfCQoje/cBkB9el8WBjokMLGBoeEjFRpctQwC8NfRn8EPyq7Mxf2pF1xRw4551+zR4wZdlg==",
             "peerDependencies": {
                 "@babylonjs/core": "^7.0.0",
                 "babylonjs-gltf2interface": "^7.0.0"
             }
         },
         "node_modules/@babylonjs/materials": {
-            "version": "7.52.1",
-            "resolved": "https://registry.npmjs.org/@babylonjs/materials/-/materials-7.52.1.tgz",
-            "integrity": "sha512-miBtz/VN4CvbNWBkLNf1qUGXrnc9k0KsF2Ge8FpZDGST09RkTh81RjrbPMxO024gAi3DvpiIA0YGf43jttKBYg==",
+            "version": "7.53.3",
+            "resolved": "https://registry.npmjs.org/@babylonjs/materials/-/materials-7.53.3.tgz",
+            "integrity": "sha512-PZMgi8udAXCDb58AdgBX4H8DNsF9rECwM2ftMarGfgKNx0pz7ge0njNrynSrOEPbBdg12LPWx+CF0YmHWg/nEQ==",
             "peerDependencies": {
                 "@babylonjs/core": "^7.0.0"
             }
         },
         "node_modules/@babylonjs/serializers": {
-            "version": "7.52.1",
-            "resolved": "https://registry.npmjs.org/@babylonjs/serializers/-/serializers-7.52.1.tgz",
-            "integrity": "sha512-D3A3rhKPnSinFpWa8TzXtlWYehZ4TxXen5qKmBfENwu3WPvHKM2ygolQYqXOuvA51Cz/22G8F9Q3ODk+9AcMhg==",
+            "version": "7.53.3",
+            "resolved": "https://registry.npmjs.org/@babylonjs/serializers/-/serializers-7.53.3.tgz",
+            "integrity": "sha512-2fhWfWVlnC93d2jaEMPsSjWBYHfWaVXZ/AhV/o8/8cAAzXFASw+xiPrTIUTHHoJ2XS7Xsm5BrlN/FOOy+gTOdA==",
             "peerDependencies": {
                 "@babylonjs/core": "^7.0.0",
                 "babylonjs-gltf2interface": "^7.0.0"
@@ -1755,30 +1755,30 @@
             "dev": true
         },
         "node_modules/@bitbybit-dev/base": {
-            "version": "0.19.6",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/base/-/base-0.19.6.tgz",
-            "integrity": "sha512-agzJ9NySDaxsuDj1/891JFhHuMq6OFEuGp/zczkfYuQbEEJexwbnACZI6UqOaEQq8sTte0bSBGKJOgt819WMSQ=="
+            "version": "0.19.7",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/base/-/base-0.19.7.tgz",
+            "integrity": "sha512-FxwZuX1GWUwROBEkSx0v/Y6VoK+dH/PtDoR+RIZ9NFPIVJRQHHCbAQ8+ZNBYuTnhr3qhoZKwfKzzzQz40EtxQw=="
         },
         "node_modules/@bitbybit-dev/core": {
-            "version": "0.19.6",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/core/-/core-0.19.6.tgz",
-            "integrity": "sha512-HqWVTWVciFS209G9Vg1pJLCk3Cbn3uBADOq1Kmr6Are8gN7Xh5rU3cKBI1/rC7+KQgVQDjJxc+mjv1bKkBNqbQ==",
+            "version": "0.19.7",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/core/-/core-0.19.7.tgz",
+            "integrity": "sha512-6fE+S93N2VzQJ/srsj4l87odcRy6S8xVewUoyyfcoWnwRwtfw1kY/1TkoWCmkM6//MqmpKLyEeTKVCra50qrrg==",
             "dependencies": {
-                "@bitbybit-dev/base": "0.19.6",
-                "@bitbybit-dev/jscad-worker": "0.19.6",
-                "@bitbybit-dev/manifold-worker": "0.19.6",
-                "@bitbybit-dev/occt-worker": "0.19.6",
+                "@bitbybit-dev/base": "0.19.7",
+                "@bitbybit-dev/jscad-worker": "0.19.7",
+                "@bitbybit-dev/manifold-worker": "0.19.7",
+                "@bitbybit-dev/occt-worker": "0.19.7",
                 "jsonpath-plus": "10.1.0",
                 "rxjs": "7.5.5",
                 "verb-nurbs-web": "2.1.3"
             }
         },
         "node_modules/@bitbybit-dev/jscad": {
-            "version": "0.19.6",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/jscad/-/jscad-0.19.6.tgz",
-            "integrity": "sha512-KRKQsMy6GT+Xg3djkfzRMFpaAXqtcQcdN74W6FXn4isOpnEAUQvwpUVJhW3+1Y2o1Y+p+RwP77HdeoOEzBRKuA==",
+            "version": "0.19.7",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/jscad/-/jscad-0.19.7.tgz",
+            "integrity": "sha512-7ou8NWlGhQuX0A/oWK0wsGaYaBQEJbCdH5+RkJxFkuYj7rdiGyN17Bd2z+lQS/hKbH6CvmYLEAV1j65SqOfNVw==",
             "dependencies": {
-                "@bitbybit-dev/base": "0.19.6",
+                "@bitbybit-dev/base": "0.19.7",
                 "@jscad/3mf-serializer": "2.1.12",
                 "@jscad/dxf-serializer": "2.1.18",
                 "@jscad/io-utils": "2.0.28",
@@ -1787,42 +1787,42 @@
             }
         },
         "node_modules/@bitbybit-dev/jscad-worker": {
-            "version": "0.19.6",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/jscad-worker/-/jscad-worker-0.19.6.tgz",
-            "integrity": "sha512-4qhfcD5ok6RBWJRUDMTOPDZwxNe13s8QZzi5qzDV8TFvvvP70bvjGrfA3HwYbHcCooKNttRQhER2BAzWCkNqMg==",
+            "version": "0.19.7",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/jscad-worker/-/jscad-worker-0.19.7.tgz",
+            "integrity": "sha512-YM+ghnuwLwBWiDUKUd3oWUeUTDa6DoIcp/z3nSt8EBCkKhrCZprWzOyjamkBkBaI2qqcb3VG66I3bILKzp0+MA==",
             "dependencies": {
-                "@bitbybit-dev/jscad": "0.19.6",
+                "@bitbybit-dev/jscad": "0.19.7",
                 "rxjs": "7.5.5"
             }
         },
         "node_modules/@bitbybit-dev/manifold": {
-            "version": "0.19.6",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/manifold/-/manifold-0.19.6.tgz",
-            "integrity": "sha512-/oPc3FcDbBkuCEjpceaJmISLIZ95dbeDGEB6c1mGsAGOcnd8d+cw0QYAn8hCKa8tfHyqVOllg+SMMoyR648g9w==",
+            "version": "0.19.7",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/manifold/-/manifold-0.19.7.tgz",
+            "integrity": "sha512-VspmaXIb6unLgPdaAplHp2/MiffvafX5qgLwl0irbnB6JUFTdvehbucG8LkUzct79K7ACPS3qoSPvAR0QUlDuA==",
             "dependencies": {
                 "manifold-3d": "3.0.0"
             }
         },
         "node_modules/@bitbybit-dev/manifold-worker": {
-            "version": "0.19.6",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/manifold-worker/-/manifold-worker-0.19.6.tgz",
-            "integrity": "sha512-usH0/28tOpCgOfKOGLOFNKxNxxXRyFnHlhn2t2FP3CkI1dYUIduMvLXtWQ6yhZ/dwBPchFEwFs8MFDQFdT3TPg==",
+            "version": "0.19.7",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/manifold-worker/-/manifold-worker-0.19.7.tgz",
+            "integrity": "sha512-VDMlsr+g3WSlNYoA2Wr9XRPXAxBlrmnDDQBeMcsaToGylgkH4i7ZwEfZRhEd+EvXxnBUjPbIOrkg4mjEhYzwfA==",
             "dependencies": {
-                "@bitbybit-dev/manifold": "0.19.6",
+                "@bitbybit-dev/manifold": "0.19.7",
                 "rxjs": "7.5.5"
             }
         },
         "node_modules/@bitbybit-dev/occt": {
-            "version": "0.19.6",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/occt/-/occt-0.19.6.tgz",
-            "integrity": "sha512-qdTutaz6jRrqtDYsWDbh4zstuBXdB+FsCIMmkMJ7bxBhhobcHjqIxL0f7ehXlzrE8FsFwMkw/7rFeQOv/7IS+A=="
+            "version": "0.19.7",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/occt/-/occt-0.19.7.tgz",
+            "integrity": "sha512-MrDYcpIrhbS2xgZfhLzqbvJQTcQ7jC/d6OMYq/ZWRuQ+ssUqOiqZvIPCcAUTQcNCnLWOvY3o2Ty79oIM0XVrZw=="
         },
         "node_modules/@bitbybit-dev/occt-worker": {
-            "version": "0.19.6",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/occt-worker/-/occt-worker-0.19.6.tgz",
-            "integrity": "sha512-0scy04SIaFSG5BJRMGojJnDu5N7ciA3K5sPJjdkxX//h8BqAYSn0uX0lPUOP/7ZhFWYxvl1lHFD52L85dj4KvQ==",
+            "version": "0.19.7",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/occt-worker/-/occt-worker-0.19.7.tgz",
+            "integrity": "sha512-JJ8kuDiBNcwrLJEyoWsBAT4V4lD6jCJwrJzLQ6hQ0yib354VrJZMiQFJfvOswYXSx2heYWqp6fGN+CKtzFQphw==",
             "dependencies": {
-                "@bitbybit-dev/occt": "0.19.6",
+                "@bitbybit-dev/occt": "0.19.7",
                 "rxjs": "7.5.5"
             }
         },
@@ -8448,14 +8448,14 @@
             }
         },
         "@babylonjs/core": {
-            "version": "7.52.1",
-            "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-7.52.1.tgz",
-            "integrity": "sha512-8lRbCoBJ15JRf86F2bAmkVwA+QYKtuaieuBU4FjAHZIDrWuY+/iYMRm7XjXB/zlYaZPln3zBYn+0K3YWYMrxWA=="
+            "version": "7.53.3",
+            "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-7.53.3.tgz",
+            "integrity": "sha512-clM03775eJ1X/kacTIZNji/1D2XMNQy57jTWGaUWDDlzDQoBeOpbIjhANfSeEsgeEM02diXrCkrfpMOcUHx2Ag=="
         },
         "@babylonjs/gui": {
-            "version": "7.52.1",
-            "resolved": "https://registry.npmjs.org/@babylonjs/gui/-/gui-7.52.1.tgz",
-            "integrity": "sha512-MAylZzvdJnVlMtvimNSbd7MovcwnGoKBLiR9z+6FHMweagxfp03xomyvngB5F4GSq8JrTvfMcI1H8LGCkyNo8w==",
+            "version": "7.53.3",
+            "resolved": "https://registry.npmjs.org/@babylonjs/gui/-/gui-7.53.3.tgz",
+            "integrity": "sha512-qH/eoX8QI7tvdKctiI5ody8sFgDDrtElYa0lDwAhSx4UqkqRlBTHUwfALz4SBAA39xh0kubaKqWsPbLflCNjGA==",
             "requires": {}
         },
         "@babylonjs/havok": {
@@ -8467,21 +8467,21 @@
             }
         },
         "@babylonjs/loaders": {
-            "version": "7.52.1",
-            "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-7.52.1.tgz",
-            "integrity": "sha512-h9hiDXt4YTBlrxBspmXM1C89B3otLVUs1P1MrEXIH2+YRN/zUAns+t8oG20Nag1tcmuMSGDkJ+3K+64v0/0+Bw==",
+            "version": "7.53.3",
+            "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-7.53.3.tgz",
+            "integrity": "sha512-NtrubMAQ+3kEqEVNfCQoje/cBkB9el8WBjokMLGBoeEjFRpctQwC8NfRn8EPyq7Mxf2pF1xRw4551+zR4wZdlg==",
             "requires": {}
         },
         "@babylonjs/materials": {
-            "version": "7.52.1",
-            "resolved": "https://registry.npmjs.org/@babylonjs/materials/-/materials-7.52.1.tgz",
-            "integrity": "sha512-miBtz/VN4CvbNWBkLNf1qUGXrnc9k0KsF2Ge8FpZDGST09RkTh81RjrbPMxO024gAi3DvpiIA0YGf43jttKBYg==",
+            "version": "7.53.3",
+            "resolved": "https://registry.npmjs.org/@babylonjs/materials/-/materials-7.53.3.tgz",
+            "integrity": "sha512-PZMgi8udAXCDb58AdgBX4H8DNsF9rECwM2ftMarGfgKNx0pz7ge0njNrynSrOEPbBdg12LPWx+CF0YmHWg/nEQ==",
             "requires": {}
         },
         "@babylonjs/serializers": {
-            "version": "7.52.1",
-            "resolved": "https://registry.npmjs.org/@babylonjs/serializers/-/serializers-7.52.1.tgz",
-            "integrity": "sha512-D3A3rhKPnSinFpWa8TzXtlWYehZ4TxXen5qKmBfENwu3WPvHKM2ygolQYqXOuvA51Cz/22G8F9Q3ODk+9AcMhg==",
+            "version": "7.53.3",
+            "resolved": "https://registry.npmjs.org/@babylonjs/serializers/-/serializers-7.53.3.tgz",
+            "integrity": "sha512-2fhWfWVlnC93d2jaEMPsSjWBYHfWaVXZ/AhV/o8/8cAAzXFASw+xiPrTIUTHHoJ2XS7Xsm5BrlN/FOOy+gTOdA==",
             "requires": {}
         },
         "@bcoe/v8-coverage": {
@@ -8491,30 +8491,30 @@
             "dev": true
         },
         "@bitbybit-dev/base": {
-            "version": "0.19.6",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/base/-/base-0.19.6.tgz",
-            "integrity": "sha512-agzJ9NySDaxsuDj1/891JFhHuMq6OFEuGp/zczkfYuQbEEJexwbnACZI6UqOaEQq8sTte0bSBGKJOgt819WMSQ=="
+            "version": "0.19.7",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/base/-/base-0.19.7.tgz",
+            "integrity": "sha512-FxwZuX1GWUwROBEkSx0v/Y6VoK+dH/PtDoR+RIZ9NFPIVJRQHHCbAQ8+ZNBYuTnhr3qhoZKwfKzzzQz40EtxQw=="
         },
         "@bitbybit-dev/core": {
-            "version": "0.19.6",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/core/-/core-0.19.6.tgz",
-            "integrity": "sha512-HqWVTWVciFS209G9Vg1pJLCk3Cbn3uBADOq1Kmr6Are8gN7Xh5rU3cKBI1/rC7+KQgVQDjJxc+mjv1bKkBNqbQ==",
+            "version": "0.19.7",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/core/-/core-0.19.7.tgz",
+            "integrity": "sha512-6fE+S93N2VzQJ/srsj4l87odcRy6S8xVewUoyyfcoWnwRwtfw1kY/1TkoWCmkM6//MqmpKLyEeTKVCra50qrrg==",
             "requires": {
-                "@bitbybit-dev/base": "0.19.6",
-                "@bitbybit-dev/jscad-worker": "0.19.6",
-                "@bitbybit-dev/manifold-worker": "0.19.6",
-                "@bitbybit-dev/occt-worker": "0.19.6",
+                "@bitbybit-dev/base": "0.19.7",
+                "@bitbybit-dev/jscad-worker": "0.19.7",
+                "@bitbybit-dev/manifold-worker": "0.19.7",
+                "@bitbybit-dev/occt-worker": "0.19.7",
                 "jsonpath-plus": "10.1.0",
                 "rxjs": "7.5.5",
                 "verb-nurbs-web": "2.1.3"
             }
         },
         "@bitbybit-dev/jscad": {
-            "version": "0.19.6",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/jscad/-/jscad-0.19.6.tgz",
-            "integrity": "sha512-KRKQsMy6GT+Xg3djkfzRMFpaAXqtcQcdN74W6FXn4isOpnEAUQvwpUVJhW3+1Y2o1Y+p+RwP77HdeoOEzBRKuA==",
+            "version": "0.19.7",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/jscad/-/jscad-0.19.7.tgz",
+            "integrity": "sha512-7ou8NWlGhQuX0A/oWK0wsGaYaBQEJbCdH5+RkJxFkuYj7rdiGyN17Bd2z+lQS/hKbH6CvmYLEAV1j65SqOfNVw==",
             "requires": {
-                "@bitbybit-dev/base": "0.19.6",
+                "@bitbybit-dev/base": "0.19.7",
                 "@jscad/3mf-serializer": "2.1.12",
                 "@jscad/dxf-serializer": "2.1.18",
                 "@jscad/io-utils": "2.0.28",
@@ -8523,42 +8523,42 @@
             }
         },
         "@bitbybit-dev/jscad-worker": {
-            "version": "0.19.6",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/jscad-worker/-/jscad-worker-0.19.6.tgz",
-            "integrity": "sha512-4qhfcD5ok6RBWJRUDMTOPDZwxNe13s8QZzi5qzDV8TFvvvP70bvjGrfA3HwYbHcCooKNttRQhER2BAzWCkNqMg==",
+            "version": "0.19.7",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/jscad-worker/-/jscad-worker-0.19.7.tgz",
+            "integrity": "sha512-YM+ghnuwLwBWiDUKUd3oWUeUTDa6DoIcp/z3nSt8EBCkKhrCZprWzOyjamkBkBaI2qqcb3VG66I3bILKzp0+MA==",
             "requires": {
-                "@bitbybit-dev/jscad": "0.19.6",
+                "@bitbybit-dev/jscad": "0.19.7",
                 "rxjs": "7.5.5"
             }
         },
         "@bitbybit-dev/manifold": {
-            "version": "0.19.6",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/manifold/-/manifold-0.19.6.tgz",
-            "integrity": "sha512-/oPc3FcDbBkuCEjpceaJmISLIZ95dbeDGEB6c1mGsAGOcnd8d+cw0QYAn8hCKa8tfHyqVOllg+SMMoyR648g9w==",
+            "version": "0.19.7",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/manifold/-/manifold-0.19.7.tgz",
+            "integrity": "sha512-VspmaXIb6unLgPdaAplHp2/MiffvafX5qgLwl0irbnB6JUFTdvehbucG8LkUzct79K7ACPS3qoSPvAR0QUlDuA==",
             "requires": {
                 "manifold-3d": "3.0.0"
             }
         },
         "@bitbybit-dev/manifold-worker": {
-            "version": "0.19.6",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/manifold-worker/-/manifold-worker-0.19.6.tgz",
-            "integrity": "sha512-usH0/28tOpCgOfKOGLOFNKxNxxXRyFnHlhn2t2FP3CkI1dYUIduMvLXtWQ6yhZ/dwBPchFEwFs8MFDQFdT3TPg==",
+            "version": "0.19.7",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/manifold-worker/-/manifold-worker-0.19.7.tgz",
+            "integrity": "sha512-VDMlsr+g3WSlNYoA2Wr9XRPXAxBlrmnDDQBeMcsaToGylgkH4i7ZwEfZRhEd+EvXxnBUjPbIOrkg4mjEhYzwfA==",
             "requires": {
-                "@bitbybit-dev/manifold": "0.19.6",
+                "@bitbybit-dev/manifold": "0.19.7",
                 "rxjs": "7.5.5"
             }
         },
         "@bitbybit-dev/occt": {
-            "version": "0.19.6",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/occt/-/occt-0.19.6.tgz",
-            "integrity": "sha512-qdTutaz6jRrqtDYsWDbh4zstuBXdB+FsCIMmkMJ7bxBhhobcHjqIxL0f7ehXlzrE8FsFwMkw/7rFeQOv/7IS+A=="
+            "version": "0.19.7",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/occt/-/occt-0.19.7.tgz",
+            "integrity": "sha512-MrDYcpIrhbS2xgZfhLzqbvJQTcQ7jC/d6OMYq/ZWRuQ+ssUqOiqZvIPCcAUTQcNCnLWOvY3o2Ty79oIM0XVrZw=="
         },
         "@bitbybit-dev/occt-worker": {
-            "version": "0.19.6",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/occt-worker/-/occt-worker-0.19.6.tgz",
-            "integrity": "sha512-0scy04SIaFSG5BJRMGojJnDu5N7ciA3K5sPJjdkxX//h8BqAYSn0uX0lPUOP/7ZhFWYxvl1lHFD52L85dj4KvQ==",
+            "version": "0.19.7",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/occt-worker/-/occt-worker-0.19.7.tgz",
+            "integrity": "sha512-JJ8kuDiBNcwrLJEyoWsBAT4V4lD6jCJwrJzLQ6hQ0yib354VrJZMiQFJfvOswYXSx2heYWqp6fGN+CKtzFQphw==",
             "requires": {
-                "@bitbybit-dev/occt": "0.19.6",
+                "@bitbybit-dev/occt": "0.19.7",
                 "rxjs": "7.5.5"
             }
         },

--- a/packages/dev/babylonjs/package.json
+++ b/packages/dev/babylonjs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bitbybit-dev/babylonjs",
-    "version": "0.19.6",
+    "version": "0.19.7",
     "description": "Bit By Bit Developers BABYLONJS CAD Library to Program Geometry",
     "main": "index.js",
     "repository": {
@@ -54,13 +54,13 @@
     "types": "./index.d.ts",
     "type": "module",
     "dependencies": {
-        "@babylonjs/core": "7.52.1",
-        "@babylonjs/gui": "7.52.1",
-        "@babylonjs/loaders": "7.52.1",
-        "@babylonjs/materials": "7.52.1",
-        "@babylonjs/serializers": "7.52.1",
+        "@babylonjs/core": "7.53.3",
+        "@babylonjs/gui": "7.53.3",
+        "@babylonjs/loaders": "7.53.3",
+        "@babylonjs/materials": "7.53.3",
+        "@babylonjs/serializers": "7.53.3",
         "@babylonjs/havok": "1.3.10",
-        "@bitbybit-dev/core": "0.19.6",
+        "@bitbybit-dev/core": "0.19.7",
         "earcut": "2.2.3"
     },
     "devDependencies": {

--- a/packages/dev/base/package-lock.json
+++ b/packages/dev/base/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@bitbybit-dev/base",
-    "version": "0.19.6",
+    "version": "0.19.7",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@bitbybit-dev/base",
-            "version": "0.19.6",
+            "version": "0.19.7",
             "license": "MIT",
             "devDependencies": {
                 "@babel/core": "7.16.0",

--- a/packages/dev/base/package.json
+++ b/packages/dev/base/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bitbybit-dev/base",
-    "version": "0.19.6",
+    "version": "0.19.7",
     "description": "Bit By Bit Developers Base CAD Library to Program Geometry",
     "main": "index.js",
     "repository": {

--- a/packages/dev/core/package-lock.json
+++ b/packages/dev/core/package-lock.json
@@ -1,18 +1,18 @@
 {
     "name": "@bitbybit-dev/core",
-    "version": "0.19.6",
+    "version": "0.19.7",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@bitbybit-dev/core",
-            "version": "0.19.6",
+            "version": "0.19.7",
             "license": "MIT",
             "dependencies": {
-                "@bitbybit-dev/base": "0.19.6",
-                "@bitbybit-dev/jscad-worker": "0.19.6",
-                "@bitbybit-dev/manifold-worker": "0.19.6",
-                "@bitbybit-dev/occt-worker": "0.19.6",
+                "@bitbybit-dev/base": "0.19.7",
+                "@bitbybit-dev/jscad-worker": "0.19.7",
+                "@bitbybit-dev/manifold-worker": "0.19.7",
+                "@bitbybit-dev/occt-worker": "0.19.7",
                 "jsonpath-plus": "10.1.0",
                 "rxjs": "7.5.5",
                 "verb-nurbs-web": "2.1.3"
@@ -1707,16 +1707,16 @@
             "dev": true
         },
         "node_modules/@bitbybit-dev/base": {
-            "version": "0.19.6",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/base/-/base-0.19.6.tgz",
-            "integrity": "sha512-agzJ9NySDaxsuDj1/891JFhHuMq6OFEuGp/zczkfYuQbEEJexwbnACZI6UqOaEQq8sTte0bSBGKJOgt819WMSQ=="
+            "version": "0.19.7",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/base/-/base-0.19.7.tgz",
+            "integrity": "sha512-FxwZuX1GWUwROBEkSx0v/Y6VoK+dH/PtDoR+RIZ9NFPIVJRQHHCbAQ8+ZNBYuTnhr3qhoZKwfKzzzQz40EtxQw=="
         },
         "node_modules/@bitbybit-dev/jscad": {
-            "version": "0.19.6",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/jscad/-/jscad-0.19.6.tgz",
-            "integrity": "sha512-KRKQsMy6GT+Xg3djkfzRMFpaAXqtcQcdN74W6FXn4isOpnEAUQvwpUVJhW3+1Y2o1Y+p+RwP77HdeoOEzBRKuA==",
+            "version": "0.19.7",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/jscad/-/jscad-0.19.7.tgz",
+            "integrity": "sha512-7ou8NWlGhQuX0A/oWK0wsGaYaBQEJbCdH5+RkJxFkuYj7rdiGyN17Bd2z+lQS/hKbH6CvmYLEAV1j65SqOfNVw==",
             "dependencies": {
-                "@bitbybit-dev/base": "0.19.6",
+                "@bitbybit-dev/base": "0.19.7",
                 "@jscad/3mf-serializer": "2.1.12",
                 "@jscad/dxf-serializer": "2.1.18",
                 "@jscad/io-utils": "2.0.28",
@@ -1725,42 +1725,42 @@
             }
         },
         "node_modules/@bitbybit-dev/jscad-worker": {
-            "version": "0.19.6",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/jscad-worker/-/jscad-worker-0.19.6.tgz",
-            "integrity": "sha512-4qhfcD5ok6RBWJRUDMTOPDZwxNe13s8QZzi5qzDV8TFvvvP70bvjGrfA3HwYbHcCooKNttRQhER2BAzWCkNqMg==",
+            "version": "0.19.7",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/jscad-worker/-/jscad-worker-0.19.7.tgz",
+            "integrity": "sha512-YM+ghnuwLwBWiDUKUd3oWUeUTDa6DoIcp/z3nSt8EBCkKhrCZprWzOyjamkBkBaI2qqcb3VG66I3bILKzp0+MA==",
             "dependencies": {
-                "@bitbybit-dev/jscad": "0.19.6",
+                "@bitbybit-dev/jscad": "0.19.7",
                 "rxjs": "7.5.5"
             }
         },
         "node_modules/@bitbybit-dev/manifold": {
-            "version": "0.19.6",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/manifold/-/manifold-0.19.6.tgz",
-            "integrity": "sha512-/oPc3FcDbBkuCEjpceaJmISLIZ95dbeDGEB6c1mGsAGOcnd8d+cw0QYAn8hCKa8tfHyqVOllg+SMMoyR648g9w==",
+            "version": "0.19.7",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/manifold/-/manifold-0.19.7.tgz",
+            "integrity": "sha512-VspmaXIb6unLgPdaAplHp2/MiffvafX5qgLwl0irbnB6JUFTdvehbucG8LkUzct79K7ACPS3qoSPvAR0QUlDuA==",
             "dependencies": {
                 "manifold-3d": "3.0.0"
             }
         },
         "node_modules/@bitbybit-dev/manifold-worker": {
-            "version": "0.19.6",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/manifold-worker/-/manifold-worker-0.19.6.tgz",
-            "integrity": "sha512-usH0/28tOpCgOfKOGLOFNKxNxxXRyFnHlhn2t2FP3CkI1dYUIduMvLXtWQ6yhZ/dwBPchFEwFs8MFDQFdT3TPg==",
+            "version": "0.19.7",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/manifold-worker/-/manifold-worker-0.19.7.tgz",
+            "integrity": "sha512-VDMlsr+g3WSlNYoA2Wr9XRPXAxBlrmnDDQBeMcsaToGylgkH4i7ZwEfZRhEd+EvXxnBUjPbIOrkg4mjEhYzwfA==",
             "dependencies": {
-                "@bitbybit-dev/manifold": "0.19.6",
+                "@bitbybit-dev/manifold": "0.19.7",
                 "rxjs": "7.5.5"
             }
         },
         "node_modules/@bitbybit-dev/occt": {
-            "version": "0.19.6",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/occt/-/occt-0.19.6.tgz",
-            "integrity": "sha512-qdTutaz6jRrqtDYsWDbh4zstuBXdB+FsCIMmkMJ7bxBhhobcHjqIxL0f7ehXlzrE8FsFwMkw/7rFeQOv/7IS+A=="
+            "version": "0.19.7",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/occt/-/occt-0.19.7.tgz",
+            "integrity": "sha512-MrDYcpIrhbS2xgZfhLzqbvJQTcQ7jC/d6OMYq/ZWRuQ+ssUqOiqZvIPCcAUTQcNCnLWOvY3o2Ty79oIM0XVrZw=="
         },
         "node_modules/@bitbybit-dev/occt-worker": {
-            "version": "0.19.6",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/occt-worker/-/occt-worker-0.19.6.tgz",
-            "integrity": "sha512-0scy04SIaFSG5BJRMGojJnDu5N7ciA3K5sPJjdkxX//h8BqAYSn0uX0lPUOP/7ZhFWYxvl1lHFD52L85dj4KvQ==",
+            "version": "0.19.7",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/occt-worker/-/occt-worker-0.19.7.tgz",
+            "integrity": "sha512-JJ8kuDiBNcwrLJEyoWsBAT4V4lD6jCJwrJzLQ6hQ0yib354VrJZMiQFJfvOswYXSx2heYWqp6fGN+CKtzFQphw==",
             "dependencies": {
-                "@bitbybit-dev/occt": "0.19.6",
+                "@bitbybit-dev/occt": "0.19.7",
                 "rxjs": "7.5.5"
             }
         },
@@ -8376,16 +8376,16 @@
             "dev": true
         },
         "@bitbybit-dev/base": {
-            "version": "0.19.6",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/base/-/base-0.19.6.tgz",
-            "integrity": "sha512-agzJ9NySDaxsuDj1/891JFhHuMq6OFEuGp/zczkfYuQbEEJexwbnACZI6UqOaEQq8sTte0bSBGKJOgt819WMSQ=="
+            "version": "0.19.7",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/base/-/base-0.19.7.tgz",
+            "integrity": "sha512-FxwZuX1GWUwROBEkSx0v/Y6VoK+dH/PtDoR+RIZ9NFPIVJRQHHCbAQ8+ZNBYuTnhr3qhoZKwfKzzzQz40EtxQw=="
         },
         "@bitbybit-dev/jscad": {
-            "version": "0.19.6",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/jscad/-/jscad-0.19.6.tgz",
-            "integrity": "sha512-KRKQsMy6GT+Xg3djkfzRMFpaAXqtcQcdN74W6FXn4isOpnEAUQvwpUVJhW3+1Y2o1Y+p+RwP77HdeoOEzBRKuA==",
+            "version": "0.19.7",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/jscad/-/jscad-0.19.7.tgz",
+            "integrity": "sha512-7ou8NWlGhQuX0A/oWK0wsGaYaBQEJbCdH5+RkJxFkuYj7rdiGyN17Bd2z+lQS/hKbH6CvmYLEAV1j65SqOfNVw==",
             "requires": {
-                "@bitbybit-dev/base": "0.19.6",
+                "@bitbybit-dev/base": "0.19.7",
                 "@jscad/3mf-serializer": "2.1.12",
                 "@jscad/dxf-serializer": "2.1.18",
                 "@jscad/io-utils": "2.0.28",
@@ -8394,42 +8394,42 @@
             }
         },
         "@bitbybit-dev/jscad-worker": {
-            "version": "0.19.6",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/jscad-worker/-/jscad-worker-0.19.6.tgz",
-            "integrity": "sha512-4qhfcD5ok6RBWJRUDMTOPDZwxNe13s8QZzi5qzDV8TFvvvP70bvjGrfA3HwYbHcCooKNttRQhER2BAzWCkNqMg==",
+            "version": "0.19.7",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/jscad-worker/-/jscad-worker-0.19.7.tgz",
+            "integrity": "sha512-YM+ghnuwLwBWiDUKUd3oWUeUTDa6DoIcp/z3nSt8EBCkKhrCZprWzOyjamkBkBaI2qqcb3VG66I3bILKzp0+MA==",
             "requires": {
-                "@bitbybit-dev/jscad": "0.19.6",
+                "@bitbybit-dev/jscad": "0.19.7",
                 "rxjs": "7.5.5"
             }
         },
         "@bitbybit-dev/manifold": {
-            "version": "0.19.6",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/manifold/-/manifold-0.19.6.tgz",
-            "integrity": "sha512-/oPc3FcDbBkuCEjpceaJmISLIZ95dbeDGEB6c1mGsAGOcnd8d+cw0QYAn8hCKa8tfHyqVOllg+SMMoyR648g9w==",
+            "version": "0.19.7",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/manifold/-/manifold-0.19.7.tgz",
+            "integrity": "sha512-VspmaXIb6unLgPdaAplHp2/MiffvafX5qgLwl0irbnB6JUFTdvehbucG8LkUzct79K7ACPS3qoSPvAR0QUlDuA==",
             "requires": {
                 "manifold-3d": "3.0.0"
             }
         },
         "@bitbybit-dev/manifold-worker": {
-            "version": "0.19.6",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/manifold-worker/-/manifold-worker-0.19.6.tgz",
-            "integrity": "sha512-usH0/28tOpCgOfKOGLOFNKxNxxXRyFnHlhn2t2FP3CkI1dYUIduMvLXtWQ6yhZ/dwBPchFEwFs8MFDQFdT3TPg==",
+            "version": "0.19.7",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/manifold-worker/-/manifold-worker-0.19.7.tgz",
+            "integrity": "sha512-VDMlsr+g3WSlNYoA2Wr9XRPXAxBlrmnDDQBeMcsaToGylgkH4i7ZwEfZRhEd+EvXxnBUjPbIOrkg4mjEhYzwfA==",
             "requires": {
-                "@bitbybit-dev/manifold": "0.19.6",
+                "@bitbybit-dev/manifold": "0.19.7",
                 "rxjs": "7.5.5"
             }
         },
         "@bitbybit-dev/occt": {
-            "version": "0.19.6",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/occt/-/occt-0.19.6.tgz",
-            "integrity": "sha512-qdTutaz6jRrqtDYsWDbh4zstuBXdB+FsCIMmkMJ7bxBhhobcHjqIxL0f7ehXlzrE8FsFwMkw/7rFeQOv/7IS+A=="
+            "version": "0.19.7",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/occt/-/occt-0.19.7.tgz",
+            "integrity": "sha512-MrDYcpIrhbS2xgZfhLzqbvJQTcQ7jC/d6OMYq/ZWRuQ+ssUqOiqZvIPCcAUTQcNCnLWOvY3o2Ty79oIM0XVrZw=="
         },
         "@bitbybit-dev/occt-worker": {
-            "version": "0.19.6",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/occt-worker/-/occt-worker-0.19.6.tgz",
-            "integrity": "sha512-0scy04SIaFSG5BJRMGojJnDu5N7ciA3K5sPJjdkxX//h8BqAYSn0uX0lPUOP/7ZhFWYxvl1lHFD52L85dj4KvQ==",
+            "version": "0.19.7",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/occt-worker/-/occt-worker-0.19.7.tgz",
+            "integrity": "sha512-JJ8kuDiBNcwrLJEyoWsBAT4V4lD6jCJwrJzLQ6hQ0yib354VrJZMiQFJfvOswYXSx2heYWqp6fGN+CKtzFQphw==",
             "requires": {
-                "@bitbybit-dev/occt": "0.19.6",
+                "@bitbybit-dev/occt": "0.19.7",
                 "rxjs": "7.5.5"
             }
         },

--- a/packages/dev/core/package.json
+++ b/packages/dev/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bitbybit-dev/core",
-    "version": "0.19.6",
+    "version": "0.19.7",
     "description": "Bit By Bit Developers Core CAD API to Program Geometry",
     "main": "index.js",
     "repository": {
@@ -54,10 +54,10 @@
     "types": "./index.d.ts",
     "type": "module",
     "dependencies": {
-        "@bitbybit-dev/base": "0.19.6",
-        "@bitbybit-dev/occt-worker": "0.19.6",
-        "@bitbybit-dev/manifold-worker": "0.19.6",
-        "@bitbybit-dev/jscad-worker": "0.19.6",
+        "@bitbybit-dev/base": "0.19.7",
+        "@bitbybit-dev/occt-worker": "0.19.7",
+        "@bitbybit-dev/manifold-worker": "0.19.7",
+        "@bitbybit-dev/jscad-worker": "0.19.7",
         "jsonpath-plus": "10.1.0",
         "verb-nurbs-web": "2.1.3",
         "rxjs": "7.5.5"

--- a/packages/dev/jscad-worker/package-lock.json
+++ b/packages/dev/jscad-worker/package-lock.json
@@ -1,15 +1,15 @@
 {
     "name": "@bitbybit-dev/jscad-worker",
-    "version": "0.19.6",
+    "version": "0.19.7",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@bitbybit-dev/jscad-worker",
-            "version": "0.19.6",
+            "version": "0.19.7",
             "license": "MIT",
             "dependencies": {
-                "@bitbybit-dev/jscad": "0.19.6",
+                "@bitbybit-dev/jscad": "0.19.7",
                 "rxjs": "7.5.5"
             },
             "devDependencies": {
@@ -1702,16 +1702,16 @@
             "dev": true
         },
         "node_modules/@bitbybit-dev/base": {
-            "version": "0.19.6",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/base/-/base-0.19.6.tgz",
-            "integrity": "sha512-agzJ9NySDaxsuDj1/891JFhHuMq6OFEuGp/zczkfYuQbEEJexwbnACZI6UqOaEQq8sTte0bSBGKJOgt819WMSQ=="
+            "version": "0.19.7",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/base/-/base-0.19.7.tgz",
+            "integrity": "sha512-FxwZuX1GWUwROBEkSx0v/Y6VoK+dH/PtDoR+RIZ9NFPIVJRQHHCbAQ8+ZNBYuTnhr3qhoZKwfKzzzQz40EtxQw=="
         },
         "node_modules/@bitbybit-dev/jscad": {
-            "version": "0.19.6",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/jscad/-/jscad-0.19.6.tgz",
-            "integrity": "sha512-KRKQsMy6GT+Xg3djkfzRMFpaAXqtcQcdN74W6FXn4isOpnEAUQvwpUVJhW3+1Y2o1Y+p+RwP77HdeoOEzBRKuA==",
+            "version": "0.19.7",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/jscad/-/jscad-0.19.7.tgz",
+            "integrity": "sha512-7ou8NWlGhQuX0A/oWK0wsGaYaBQEJbCdH5+RkJxFkuYj7rdiGyN17Bd2z+lQS/hKbH6CvmYLEAV1j65SqOfNVw==",
             "dependencies": {
-                "@bitbybit-dev/base": "0.19.6",
+                "@bitbybit-dev/base": "0.19.7",
                 "@jscad/3mf-serializer": "2.1.12",
                 "@jscad/dxf-serializer": "2.1.18",
                 "@jscad/io-utils": "2.0.28",
@@ -8236,16 +8236,16 @@
             "dev": true
         },
         "@bitbybit-dev/base": {
-            "version": "0.19.6",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/base/-/base-0.19.6.tgz",
-            "integrity": "sha512-agzJ9NySDaxsuDj1/891JFhHuMq6OFEuGp/zczkfYuQbEEJexwbnACZI6UqOaEQq8sTte0bSBGKJOgt819WMSQ=="
+            "version": "0.19.7",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/base/-/base-0.19.7.tgz",
+            "integrity": "sha512-FxwZuX1GWUwROBEkSx0v/Y6VoK+dH/PtDoR+RIZ9NFPIVJRQHHCbAQ8+ZNBYuTnhr3qhoZKwfKzzzQz40EtxQw=="
         },
         "@bitbybit-dev/jscad": {
-            "version": "0.19.6",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/jscad/-/jscad-0.19.6.tgz",
-            "integrity": "sha512-KRKQsMy6GT+Xg3djkfzRMFpaAXqtcQcdN74W6FXn4isOpnEAUQvwpUVJhW3+1Y2o1Y+p+RwP77HdeoOEzBRKuA==",
+            "version": "0.19.7",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/jscad/-/jscad-0.19.7.tgz",
+            "integrity": "sha512-7ou8NWlGhQuX0A/oWK0wsGaYaBQEJbCdH5+RkJxFkuYj7rdiGyN17Bd2z+lQS/hKbH6CvmYLEAV1j65SqOfNVw==",
             "requires": {
-                "@bitbybit-dev/base": "0.19.6",
+                "@bitbybit-dev/base": "0.19.7",
                 "@jscad/3mf-serializer": "2.1.12",
                 "@jscad/dxf-serializer": "2.1.18",
                 "@jscad/io-utils": "2.0.28",

--- a/packages/dev/jscad-worker/package.json
+++ b/packages/dev/jscad-worker/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bitbybit-dev/jscad-worker",
-    "version": "0.19.6",
+    "version": "0.19.7",
     "description": "Bit By Bit Developers JSCAD Based CAD Library to Program Geometry Via WebWorker",
     "main": "index.js",
     "repository": {
@@ -60,7 +60,7 @@
     "types": "./index.d.ts",
     "type": "module",
     "dependencies": {
-        "@bitbybit-dev/jscad": "0.19.6",
+        "@bitbybit-dev/jscad": "0.19.7",
         "rxjs": "7.5.5"
     },
     "devDependencies": {

--- a/packages/dev/jscad/package-lock.json
+++ b/packages/dev/jscad/package-lock.json
@@ -1,15 +1,15 @@
 {
     "name": "@bitbybit-dev/jscad",
-    "version": "0.19.6",
+    "version": "0.19.7",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@bitbybit-dev/jscad",
-            "version": "0.19.6",
+            "version": "0.19.7",
             "license": "MIT",
             "dependencies": {
-                "@bitbybit-dev/base": "0.19.6",
+                "@bitbybit-dev/base": "0.19.7",
                 "@jscad/3mf-serializer": "2.1.12",
                 "@jscad/dxf-serializer": "2.1.18",
                 "@jscad/io-utils": "2.0.28",
@@ -1706,9 +1706,9 @@
             "dev": true
         },
         "node_modules/@bitbybit-dev/base": {
-            "version": "0.19.6",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/base/-/base-0.19.6.tgz",
-            "integrity": "sha512-agzJ9NySDaxsuDj1/891JFhHuMq6OFEuGp/zczkfYuQbEEJexwbnACZI6UqOaEQq8sTte0bSBGKJOgt819WMSQ=="
+            "version": "0.19.7",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/base/-/base-0.19.7.tgz",
+            "integrity": "sha512-FxwZuX1GWUwROBEkSx0v/Y6VoK+dH/PtDoR+RIZ9NFPIVJRQHHCbAQ8+ZNBYuTnhr3qhoZKwfKzzzQz40EtxQw=="
         },
         "node_modules/@cspotcode/source-map-support": {
             "version": "0.8.1",
@@ -8214,9 +8214,9 @@
             "dev": true
         },
         "@bitbybit-dev/base": {
-            "version": "0.19.6",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/base/-/base-0.19.6.tgz",
-            "integrity": "sha512-agzJ9NySDaxsuDj1/891JFhHuMq6OFEuGp/zczkfYuQbEEJexwbnACZI6UqOaEQq8sTte0bSBGKJOgt819WMSQ=="
+            "version": "0.19.7",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/base/-/base-0.19.7.tgz",
+            "integrity": "sha512-FxwZuX1GWUwROBEkSx0v/Y6VoK+dH/PtDoR+RIZ9NFPIVJRQHHCbAQ8+ZNBYuTnhr3qhoZKwfKzzzQz40EtxQw=="
         },
         "@cspotcode/source-map-support": {
             "version": "0.8.1",

--- a/packages/dev/jscad/package.json
+++ b/packages/dev/jscad/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bitbybit-dev/jscad",
-    "version": "0.19.6",
+    "version": "0.19.7",
     "description": "Bit By Bit Developers JSCAD based CAD Library to Program Geometry",
     "main": "index.js",
     "repository": {
@@ -58,7 +58,7 @@
     "types": "./index.d.ts",
     "type": "module",
     "dependencies": {
-        "@bitbybit-dev/base": "0.19.6",
+        "@bitbybit-dev/base": "0.19.7",
         "@jscad/io-utils": "2.0.28",
         "@jscad/modeling": "2.12.3",
         "@jscad/stl-serializer": "2.1.18",

--- a/packages/dev/manifold-worker/package-lock.json
+++ b/packages/dev/manifold-worker/package-lock.json
@@ -1,15 +1,15 @@
 {
     "name": "@bitbybit-dev/manifold-worker",
-    "version": "0.19.6",
+    "version": "0.19.7",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@bitbybit-dev/manifold-worker",
-            "version": "0.19.6",
+            "version": "0.19.7",
             "license": "MIT",
             "dependencies": {
-                "@bitbybit-dev/manifold": "0.19.6",
+                "@bitbybit-dev/manifold": "0.19.7",
                 "rxjs": "7.5.5"
             },
             "devDependencies": {
@@ -1702,9 +1702,9 @@
             "dev": true
         },
         "node_modules/@bitbybit-dev/manifold": {
-            "version": "0.19.6",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/manifold/-/manifold-0.19.6.tgz",
-            "integrity": "sha512-/oPc3FcDbBkuCEjpceaJmISLIZ95dbeDGEB6c1mGsAGOcnd8d+cw0QYAn8hCKa8tfHyqVOllg+SMMoyR648g9w==",
+            "version": "0.19.7",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/manifold/-/manifold-0.19.7.tgz",
+            "integrity": "sha512-VspmaXIb6unLgPdaAplHp2/MiffvafX5qgLwl0irbnB6JUFTdvehbucG8LkUzct79K7ACPS3qoSPvAR0QUlDuA==",
             "dependencies": {
                 "manifold-3d": "3.0.0"
             }
@@ -8169,9 +8169,9 @@
             "dev": true
         },
         "@bitbybit-dev/manifold": {
-            "version": "0.19.6",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/manifold/-/manifold-0.19.6.tgz",
-            "integrity": "sha512-/oPc3FcDbBkuCEjpceaJmISLIZ95dbeDGEB6c1mGsAGOcnd8d+cw0QYAn8hCKa8tfHyqVOllg+SMMoyR648g9w==",
+            "version": "0.19.7",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/manifold/-/manifold-0.19.7.tgz",
+            "integrity": "sha512-VspmaXIb6unLgPdaAplHp2/MiffvafX5qgLwl0irbnB6JUFTdvehbucG8LkUzct79K7ACPS3qoSPvAR0QUlDuA==",
             "requires": {
                 "manifold-3d": "3.0.0"
             }

--- a/packages/dev/manifold-worker/package.json
+++ b/packages/dev/manifold-worker/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bitbybit-dev/manifold-worker",
-    "version": "0.19.6",
+    "version": "0.19.7",
     "description": "Bit By Bit Developers Manifold Based CAD Library to Program Geometry Via WebWorker",
     "main": "index.js",
     "repository": {
@@ -60,7 +60,7 @@
     "types": "./index.d.ts",
     "type": "module",
     "dependencies": {
-        "@bitbybit-dev/manifold": "0.19.6",
+        "@bitbybit-dev/manifold": "0.19.7",
         "rxjs": "7.5.5"
     },
     "devDependencies": {

--- a/packages/dev/manifold/package-lock.json
+++ b/packages/dev/manifold/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@bitbybit-dev/manifold",
-    "version": "0.19.6",
+    "version": "0.19.7",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@bitbybit-dev/manifold",
-            "version": "0.19.6",
+            "version": "0.19.7",
             "license": "MIT",
             "dependencies": {
                 "manifold-3d": "3.0.0"

--- a/packages/dev/manifold/package.json
+++ b/packages/dev/manifold/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bitbybit-dev/manifold",
-    "version": "0.19.6",
+    "version": "0.19.7",
     "description": "Bit By Bit Developers Manifold based CAD Library to Program Geometry",
     "main": "index.js",
     "repository": {

--- a/packages/dev/occt-worker/package-lock.json
+++ b/packages/dev/occt-worker/package-lock.json
@@ -1,15 +1,15 @@
 {
     "name": "@bitbybit-dev/occt-worker",
-    "version": "0.19.6",
+    "version": "0.19.7",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@bitbybit-dev/occt-worker",
-            "version": "0.19.6",
+            "version": "0.19.7",
             "license": "MIT",
             "dependencies": {
-                "@bitbybit-dev/occt": "0.19.6",
+                "@bitbybit-dev/occt": "0.19.7",
                 "rxjs": "7.5.5"
             },
             "devDependencies": {
@@ -1702,9 +1702,9 @@
             "dev": true
         },
         "node_modules/@bitbybit-dev/occt": {
-            "version": "0.19.6",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/occt/-/occt-0.19.6.tgz",
-            "integrity": "sha512-qdTutaz6jRrqtDYsWDbh4zstuBXdB+FsCIMmkMJ7bxBhhobcHjqIxL0f7ehXlzrE8FsFwMkw/7rFeQOv/7IS+A=="
+            "version": "0.19.7",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/occt/-/occt-0.19.7.tgz",
+            "integrity": "sha512-MrDYcpIrhbS2xgZfhLzqbvJQTcQ7jC/d6OMYq/ZWRuQ+ssUqOiqZvIPCcAUTQcNCnLWOvY3o2Ty79oIM0XVrZw=="
         },
         "node_modules/@cspotcode/source-map-support": {
             "version": "0.8.1",
@@ -8161,9 +8161,9 @@
             "dev": true
         },
         "@bitbybit-dev/occt": {
-            "version": "0.19.6",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/occt/-/occt-0.19.6.tgz",
-            "integrity": "sha512-qdTutaz6jRrqtDYsWDbh4zstuBXdB+FsCIMmkMJ7bxBhhobcHjqIxL0f7ehXlzrE8FsFwMkw/7rFeQOv/7IS+A=="
+            "version": "0.19.7",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/occt/-/occt-0.19.7.tgz",
+            "integrity": "sha512-MrDYcpIrhbS2xgZfhLzqbvJQTcQ7jC/d6OMYq/ZWRuQ+ssUqOiqZvIPCcAUTQcNCnLWOvY3o2Ty79oIM0XVrZw=="
         },
         "@cspotcode/source-map-support": {
             "version": "0.8.1",

--- a/packages/dev/occt-worker/package.json
+++ b/packages/dev/occt-worker/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bitbybit-dev/occt-worker",
-    "version": "0.19.6",
+    "version": "0.19.7",
     "description": "Bit By Bit Developers CAD algorithms using OpenCascade Technology kernel adapted for WebWorker",
     "main": "index.js",
     "repository": {
@@ -56,7 +56,7 @@
     "types": "./index.d.ts",
     "type": "module",
     "dependencies": {
-        "@bitbybit-dev/occt": "0.19.6",
+        "@bitbybit-dev/occt": "0.19.7",
         "rxjs": "7.5.5"
     },
     "devDependencies": {

--- a/packages/dev/occt/bitbybit-dev-occt/cdn.js
+++ b/packages/dev/occt/bitbybit-dev-occt/cdn.js
@@ -2,7 +2,7 @@ import ocFullJS from "./bitbybit-dev-occt.js";
 
 const initOpenCascade = ({
   mainJS = ocFullJS,
-  mainWasm = "https://cdn.jsdelivr.net/gh/bitbybit-dev/bitbybit-assets@0.19.6/wasm/bitbybit-dev-occt.a9520351.wasm",
+  mainWasm = "https://cdn.jsdelivr.net/gh/bitbybit-dev/bitbybit-assets@0.19.7/wasm/bitbybit-dev-occt.0e7dc0dc.wasm",
   worker = undefined,
   libs = [],
   module = {},

--- a/packages/dev/occt/package-lock.json
+++ b/packages/dev/occt/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@bitbybit-dev/occt",
-    "version": "0.19.6",
+    "version": "0.19.7",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@bitbybit-dev/occt",
-            "version": "0.19.6",
+            "version": "0.19.7",
             "license": "MIT",
             "devDependencies": {
                 "@babel/core": "7.16.0",

--- a/packages/dev/occt/package.json
+++ b/packages/dev/occt/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bitbybit-dev/occt",
-    "version": "0.19.6",
+    "version": "0.19.7",
     "description": "Bit By Bit Developers CAD algorithms using OpenCascade Technology kernel. Run in Node and in Browser.",
     "main": "index.js",
     "repository": {

--- a/packages/dev/threejs/package-lock.json
+++ b/packages/dev/threejs/package-lock.json
@@ -1,15 +1,15 @@
 {
     "name": "@bitbybit-dev/threejs",
-    "version": "0.19.6",
+    "version": "0.19.7",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@bitbybit-dev/threejs",
-            "version": "0.19.6",
+            "version": "0.19.7",
             "license": "MIT",
             "dependencies": {
-                "@bitbybit-dev/core": "0.19.6",
+                "@bitbybit-dev/core": "0.19.7",
                 "three": "0.174.0"
             },
             "devDependencies": {
@@ -1703,30 +1703,30 @@
             "dev": true
         },
         "node_modules/@bitbybit-dev/base": {
-            "version": "0.19.6",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/base/-/base-0.19.6.tgz",
-            "integrity": "sha512-agzJ9NySDaxsuDj1/891JFhHuMq6OFEuGp/zczkfYuQbEEJexwbnACZI6UqOaEQq8sTte0bSBGKJOgt819WMSQ=="
+            "version": "0.19.7",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/base/-/base-0.19.7.tgz",
+            "integrity": "sha512-FxwZuX1GWUwROBEkSx0v/Y6VoK+dH/PtDoR+RIZ9NFPIVJRQHHCbAQ8+ZNBYuTnhr3qhoZKwfKzzzQz40EtxQw=="
         },
         "node_modules/@bitbybit-dev/core": {
-            "version": "0.19.6",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/core/-/core-0.19.6.tgz",
-            "integrity": "sha512-HqWVTWVciFS209G9Vg1pJLCk3Cbn3uBADOq1Kmr6Are8gN7Xh5rU3cKBI1/rC7+KQgVQDjJxc+mjv1bKkBNqbQ==",
+            "version": "0.19.7",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/core/-/core-0.19.7.tgz",
+            "integrity": "sha512-6fE+S93N2VzQJ/srsj4l87odcRy6S8xVewUoyyfcoWnwRwtfw1kY/1TkoWCmkM6//MqmpKLyEeTKVCra50qrrg==",
             "dependencies": {
-                "@bitbybit-dev/base": "0.19.6",
-                "@bitbybit-dev/jscad-worker": "0.19.6",
-                "@bitbybit-dev/manifold-worker": "0.19.6",
-                "@bitbybit-dev/occt-worker": "0.19.6",
+                "@bitbybit-dev/base": "0.19.7",
+                "@bitbybit-dev/jscad-worker": "0.19.7",
+                "@bitbybit-dev/manifold-worker": "0.19.7",
+                "@bitbybit-dev/occt-worker": "0.19.7",
                 "jsonpath-plus": "10.1.0",
                 "rxjs": "7.5.5",
                 "verb-nurbs-web": "2.1.3"
             }
         },
         "node_modules/@bitbybit-dev/jscad": {
-            "version": "0.19.6",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/jscad/-/jscad-0.19.6.tgz",
-            "integrity": "sha512-KRKQsMy6GT+Xg3djkfzRMFpaAXqtcQcdN74W6FXn4isOpnEAUQvwpUVJhW3+1Y2o1Y+p+RwP77HdeoOEzBRKuA==",
+            "version": "0.19.7",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/jscad/-/jscad-0.19.7.tgz",
+            "integrity": "sha512-7ou8NWlGhQuX0A/oWK0wsGaYaBQEJbCdH5+RkJxFkuYj7rdiGyN17Bd2z+lQS/hKbH6CvmYLEAV1j65SqOfNVw==",
             "dependencies": {
-                "@bitbybit-dev/base": "0.19.6",
+                "@bitbybit-dev/base": "0.19.7",
                 "@jscad/3mf-serializer": "2.1.12",
                 "@jscad/dxf-serializer": "2.1.18",
                 "@jscad/io-utils": "2.0.28",
@@ -1735,42 +1735,42 @@
             }
         },
         "node_modules/@bitbybit-dev/jscad-worker": {
-            "version": "0.19.6",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/jscad-worker/-/jscad-worker-0.19.6.tgz",
-            "integrity": "sha512-4qhfcD5ok6RBWJRUDMTOPDZwxNe13s8QZzi5qzDV8TFvvvP70bvjGrfA3HwYbHcCooKNttRQhER2BAzWCkNqMg==",
+            "version": "0.19.7",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/jscad-worker/-/jscad-worker-0.19.7.tgz",
+            "integrity": "sha512-YM+ghnuwLwBWiDUKUd3oWUeUTDa6DoIcp/z3nSt8EBCkKhrCZprWzOyjamkBkBaI2qqcb3VG66I3bILKzp0+MA==",
             "dependencies": {
-                "@bitbybit-dev/jscad": "0.19.6",
+                "@bitbybit-dev/jscad": "0.19.7",
                 "rxjs": "7.5.5"
             }
         },
         "node_modules/@bitbybit-dev/manifold": {
-            "version": "0.19.6",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/manifold/-/manifold-0.19.6.tgz",
-            "integrity": "sha512-/oPc3FcDbBkuCEjpceaJmISLIZ95dbeDGEB6c1mGsAGOcnd8d+cw0QYAn8hCKa8tfHyqVOllg+SMMoyR648g9w==",
+            "version": "0.19.7",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/manifold/-/manifold-0.19.7.tgz",
+            "integrity": "sha512-VspmaXIb6unLgPdaAplHp2/MiffvafX5qgLwl0irbnB6JUFTdvehbucG8LkUzct79K7ACPS3qoSPvAR0QUlDuA==",
             "dependencies": {
                 "manifold-3d": "3.0.0"
             }
         },
         "node_modules/@bitbybit-dev/manifold-worker": {
-            "version": "0.19.6",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/manifold-worker/-/manifold-worker-0.19.6.tgz",
-            "integrity": "sha512-usH0/28tOpCgOfKOGLOFNKxNxxXRyFnHlhn2t2FP3CkI1dYUIduMvLXtWQ6yhZ/dwBPchFEwFs8MFDQFdT3TPg==",
+            "version": "0.19.7",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/manifold-worker/-/manifold-worker-0.19.7.tgz",
+            "integrity": "sha512-VDMlsr+g3WSlNYoA2Wr9XRPXAxBlrmnDDQBeMcsaToGylgkH4i7ZwEfZRhEd+EvXxnBUjPbIOrkg4mjEhYzwfA==",
             "dependencies": {
-                "@bitbybit-dev/manifold": "0.19.6",
+                "@bitbybit-dev/manifold": "0.19.7",
                 "rxjs": "7.5.5"
             }
         },
         "node_modules/@bitbybit-dev/occt": {
-            "version": "0.19.6",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/occt/-/occt-0.19.6.tgz",
-            "integrity": "sha512-qdTutaz6jRrqtDYsWDbh4zstuBXdB+FsCIMmkMJ7bxBhhobcHjqIxL0f7ehXlzrE8FsFwMkw/7rFeQOv/7IS+A=="
+            "version": "0.19.7",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/occt/-/occt-0.19.7.tgz",
+            "integrity": "sha512-MrDYcpIrhbS2xgZfhLzqbvJQTcQ7jC/d6OMYq/ZWRuQ+ssUqOiqZvIPCcAUTQcNCnLWOvY3o2Ty79oIM0XVrZw=="
         },
         "node_modules/@bitbybit-dev/occt-worker": {
-            "version": "0.19.6",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/occt-worker/-/occt-worker-0.19.6.tgz",
-            "integrity": "sha512-0scy04SIaFSG5BJRMGojJnDu5N7ciA3K5sPJjdkxX//h8BqAYSn0uX0lPUOP/7ZhFWYxvl1lHFD52L85dj4KvQ==",
+            "version": "0.19.7",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/occt-worker/-/occt-worker-0.19.7.tgz",
+            "integrity": "sha512-JJ8kuDiBNcwrLJEyoWsBAT4V4lD6jCJwrJzLQ6hQ0yib354VrJZMiQFJfvOswYXSx2heYWqp6fGN+CKtzFQphw==",
             "dependencies": {
-                "@bitbybit-dev/occt": "0.19.6",
+                "@bitbybit-dev/occt": "0.19.7",
                 "rxjs": "7.5.5"
             }
         },
@@ -8441,30 +8441,30 @@
             "dev": true
         },
         "@bitbybit-dev/base": {
-            "version": "0.19.6",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/base/-/base-0.19.6.tgz",
-            "integrity": "sha512-agzJ9NySDaxsuDj1/891JFhHuMq6OFEuGp/zczkfYuQbEEJexwbnACZI6UqOaEQq8sTte0bSBGKJOgt819WMSQ=="
+            "version": "0.19.7",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/base/-/base-0.19.7.tgz",
+            "integrity": "sha512-FxwZuX1GWUwROBEkSx0v/Y6VoK+dH/PtDoR+RIZ9NFPIVJRQHHCbAQ8+ZNBYuTnhr3qhoZKwfKzzzQz40EtxQw=="
         },
         "@bitbybit-dev/core": {
-            "version": "0.19.6",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/core/-/core-0.19.6.tgz",
-            "integrity": "sha512-HqWVTWVciFS209G9Vg1pJLCk3Cbn3uBADOq1Kmr6Are8gN7Xh5rU3cKBI1/rC7+KQgVQDjJxc+mjv1bKkBNqbQ==",
+            "version": "0.19.7",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/core/-/core-0.19.7.tgz",
+            "integrity": "sha512-6fE+S93N2VzQJ/srsj4l87odcRy6S8xVewUoyyfcoWnwRwtfw1kY/1TkoWCmkM6//MqmpKLyEeTKVCra50qrrg==",
             "requires": {
-                "@bitbybit-dev/base": "0.19.6",
-                "@bitbybit-dev/jscad-worker": "0.19.6",
-                "@bitbybit-dev/manifold-worker": "0.19.6",
-                "@bitbybit-dev/occt-worker": "0.19.6",
+                "@bitbybit-dev/base": "0.19.7",
+                "@bitbybit-dev/jscad-worker": "0.19.7",
+                "@bitbybit-dev/manifold-worker": "0.19.7",
+                "@bitbybit-dev/occt-worker": "0.19.7",
                 "jsonpath-plus": "10.1.0",
                 "rxjs": "7.5.5",
                 "verb-nurbs-web": "2.1.3"
             }
         },
         "@bitbybit-dev/jscad": {
-            "version": "0.19.6",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/jscad/-/jscad-0.19.6.tgz",
-            "integrity": "sha512-KRKQsMy6GT+Xg3djkfzRMFpaAXqtcQcdN74W6FXn4isOpnEAUQvwpUVJhW3+1Y2o1Y+p+RwP77HdeoOEzBRKuA==",
+            "version": "0.19.7",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/jscad/-/jscad-0.19.7.tgz",
+            "integrity": "sha512-7ou8NWlGhQuX0A/oWK0wsGaYaBQEJbCdH5+RkJxFkuYj7rdiGyN17Bd2z+lQS/hKbH6CvmYLEAV1j65SqOfNVw==",
             "requires": {
-                "@bitbybit-dev/base": "0.19.6",
+                "@bitbybit-dev/base": "0.19.7",
                 "@jscad/3mf-serializer": "2.1.12",
                 "@jscad/dxf-serializer": "2.1.18",
                 "@jscad/io-utils": "2.0.28",
@@ -8473,42 +8473,42 @@
             }
         },
         "@bitbybit-dev/jscad-worker": {
-            "version": "0.19.6",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/jscad-worker/-/jscad-worker-0.19.6.tgz",
-            "integrity": "sha512-4qhfcD5ok6RBWJRUDMTOPDZwxNe13s8QZzi5qzDV8TFvvvP70bvjGrfA3HwYbHcCooKNttRQhER2BAzWCkNqMg==",
+            "version": "0.19.7",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/jscad-worker/-/jscad-worker-0.19.7.tgz",
+            "integrity": "sha512-YM+ghnuwLwBWiDUKUd3oWUeUTDa6DoIcp/z3nSt8EBCkKhrCZprWzOyjamkBkBaI2qqcb3VG66I3bILKzp0+MA==",
             "requires": {
-                "@bitbybit-dev/jscad": "0.19.6",
+                "@bitbybit-dev/jscad": "0.19.7",
                 "rxjs": "7.5.5"
             }
         },
         "@bitbybit-dev/manifold": {
-            "version": "0.19.6",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/manifold/-/manifold-0.19.6.tgz",
-            "integrity": "sha512-/oPc3FcDbBkuCEjpceaJmISLIZ95dbeDGEB6c1mGsAGOcnd8d+cw0QYAn8hCKa8tfHyqVOllg+SMMoyR648g9w==",
+            "version": "0.19.7",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/manifold/-/manifold-0.19.7.tgz",
+            "integrity": "sha512-VspmaXIb6unLgPdaAplHp2/MiffvafX5qgLwl0irbnB6JUFTdvehbucG8LkUzct79K7ACPS3qoSPvAR0QUlDuA==",
             "requires": {
                 "manifold-3d": "3.0.0"
             }
         },
         "@bitbybit-dev/manifold-worker": {
-            "version": "0.19.6",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/manifold-worker/-/manifold-worker-0.19.6.tgz",
-            "integrity": "sha512-usH0/28tOpCgOfKOGLOFNKxNxxXRyFnHlhn2t2FP3CkI1dYUIduMvLXtWQ6yhZ/dwBPchFEwFs8MFDQFdT3TPg==",
+            "version": "0.19.7",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/manifold-worker/-/manifold-worker-0.19.7.tgz",
+            "integrity": "sha512-VDMlsr+g3WSlNYoA2Wr9XRPXAxBlrmnDDQBeMcsaToGylgkH4i7ZwEfZRhEd+EvXxnBUjPbIOrkg4mjEhYzwfA==",
             "requires": {
-                "@bitbybit-dev/manifold": "0.19.6",
+                "@bitbybit-dev/manifold": "0.19.7",
                 "rxjs": "7.5.5"
             }
         },
         "@bitbybit-dev/occt": {
-            "version": "0.19.6",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/occt/-/occt-0.19.6.tgz",
-            "integrity": "sha512-qdTutaz6jRrqtDYsWDbh4zstuBXdB+FsCIMmkMJ7bxBhhobcHjqIxL0f7ehXlzrE8FsFwMkw/7rFeQOv/7IS+A=="
+            "version": "0.19.7",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/occt/-/occt-0.19.7.tgz",
+            "integrity": "sha512-MrDYcpIrhbS2xgZfhLzqbvJQTcQ7jC/d6OMYq/ZWRuQ+ssUqOiqZvIPCcAUTQcNCnLWOvY3o2Ty79oIM0XVrZw=="
         },
         "@bitbybit-dev/occt-worker": {
-            "version": "0.19.6",
-            "resolved": "https://registry.npmjs.org/@bitbybit-dev/occt-worker/-/occt-worker-0.19.6.tgz",
-            "integrity": "sha512-0scy04SIaFSG5BJRMGojJnDu5N7ciA3K5sPJjdkxX//h8BqAYSn0uX0lPUOP/7ZhFWYxvl1lHFD52L85dj4KvQ==",
+            "version": "0.19.7",
+            "resolved": "https://registry.npmjs.org/@bitbybit-dev/occt-worker/-/occt-worker-0.19.7.tgz",
+            "integrity": "sha512-JJ8kuDiBNcwrLJEyoWsBAT4V4lD6jCJwrJzLQ6hQ0yib354VrJZMiQFJfvOswYXSx2heYWqp6fGN+CKtzFQphw==",
             "requires": {
-                "@bitbybit-dev/occt": "0.19.6",
+                "@bitbybit-dev/occt": "0.19.7",
                 "rxjs": "7.5.5"
             }
         },

--- a/packages/dev/threejs/package.json
+++ b/packages/dev/threejs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bitbybit-dev/threejs",
-    "version": "0.19.6",
+    "version": "0.19.7",
     "description": "Bit By Bit Developers THREEJS CAD Library to Program Geometry",
     "main": "index.js",
     "repository": {
@@ -55,7 +55,7 @@
     "type": "module",
     "dependencies": {
         "three": "0.174.0",
-        "@bitbybit-dev/core": "0.19.6"
+        "@bitbybit-dev/core": "0.19.7"
     },
     "devDependencies": {
         "sass": "1.57.1",


### PR DESCRIPTION
- New OpenCascade.js build that includes GeomAPI_ProjectPointOnCurve for splitting wires in generic way.
- Fixed and improved cylindrical and n-gon pipe algorithms to support closed and periodic spines. 
- Re-written algorithm to split wires by providing a list of points.
- Additional option for revolved extrude to allow for non-solid results in cases when wires are being extruded
- Update to BabylonJS v7.53.3
- Implemented separate import that can include bitbybit-occt wasm file from jsdelivr CDN directly