### PR TITLE
Read npm pack's output in either shape, and stop taking whatever npm …

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,8 +62,11 @@ jobs:
           registry-url: https://registry.npmjs.org
           cache: pnpm
 
-      # trusted publishing needs npm 11.5.1 or newer; Node 22 bundles an older npm
-      - run: npm install -g npm@latest && npm --version
+      # Trusted publishing needs npm 11.5.1 or newer and Node 22 bundles an older one, so npm is
+      # installed here - pinned, because `@latest` silently took whatever npm shipped that morning
+      # and a change to `npm pack --json`'s output shape then failed a release mid-run. Moving this
+      # pin is a deliberate change with the gates re-run, not something a release discovers.
+      - run: npm install -g npm@11.6.2 && npm --version
 
       - run: pnpm install --frozen-lockfile
 

--- a/scripts/check-tarballs.mjs
+++ b/scripts/check-tarballs.mjs
@@ -130,7 +130,14 @@ for (const { dir, fromDist } of [...distProjects, ...rootProjects]) {
         }
     }
     checkNothingSilentlyStripped(manifest.name, publishDir, fromDist ? ["."] : (manifest.files ?? ["."]));
-    const [packed] = JSON.parse(run("npm", ["pack", "--json", "--ignore-scripts", "--pack-destination", packDir], publishDir));
+    // npm 11.6 answers with an array of one entry; a later npm answers with the entry itself, and
+    // destructuring the second as the first throws "object is not iterable" halfway through a
+    // release. Take either shape, and say which npm produced a third rather than crashing on it.
+    const packOutput = JSON.parse(run("npm", ["pack", "--json", "--ignore-scripts", "--pack-destination", packDir], publishDir));
+    const packed = Array.isArray(packOutput) ? packOutput[0] : packOutput;
+    if (!packed?.filename || !Array.isArray(packed.files)) {
+        fail(`npm ${run("npm", ["--version"]).trim()} answered \`npm pack --json\` in a shape this does not understand: ${JSON.stringify(packOutput).slice(0, 200)}`);
+    }
     const shipped = packed.files.map((f) => f.path);
     const leaked = shipped.filter((f) => f.endsWith(".tsbuildinfo") || f.endsWith(".npmignore") || f.startsWith("coverage/") || f.startsWith("babel.config"));
     if (leaked.length) fail(`${manifest.name} ships build-only files: ${leaked.join(", ")}`);


### PR DESCRIPTION
…ships today

check:tarballs destructured `npm pack --json` as an array. npm 11.6 answers with an array of one entry; a newer npm answers with the entry itself, and the publish died on "object is not iterable" after building and testing every package - the step before it publishes. The line is as old as the check; what changed was the npm underneath it.

That could change underneath it because publish.yml installed npm@latest. Every other workflow in this repository's ecosystem pins 11.6.2, and this one did not, so a release build silently took whatever npm shipped that morning. It is pinned now, and moving the pin is a deliberate change with the gates re-run rather than something a release finds out.

The parse takes either shape and names the npm version if a third ever appears, because the failure to avoid is not a shape it cannot read - it is a shape it cannot read reported as a crash halfway through a release.