### PR TITLE
Wait for the last tier too, so the smoke test stops racing the registry

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -102,7 +102,11 @@ jobs:
           mkdir -p /tmp/smoke && cd /tmp/smoke && npm init -y > /dev/null
           npm install --ignore-scripts --no-audit --no-fund --legacy-peer-deps "@bitbybit-dev/threejs@$VERSION" "@bitbybit-dev/babylonjs@$VERSION" "@bitbybit-dev/playcanvas@$VERSION" "@bitbybit-dev/cad-cloud-sdk@$VERSION"
           for p in base occt occt-worker jscad jscad-worker manifold manifold-worker core threejs babylonjs playcanvas cad-cloud-sdk; do
-            test "$(node -p "require('@bitbybit-dev/$p/package.json').version")" = "$VERSION" || { echo "@bitbybit-dev/$p resolved to another version"; exit 1; }
+            # Read the manifest off disk, not through module resolution: a package with a correct
+            # exports map need not expose ./package.json, and asking for it through the resolver
+            # then fails on the packaging rather than on the version this is checking.
+            INSTALLED=$(node -p "JSON.parse(require('fs').readFileSync('node_modules/@bitbybit-dev/$p/package.json','utf8')).version")
+            test "$INSTALLED" = "$VERSION" || { echo "@bitbybit-dev/$p installed $INSTALLED, expected $VERSION"; exit 1; }
           done
           npm view "@bitbybit-dev/core@$VERSION" --json | node -e "const j=JSON.parse(require('fs').readFileSync(0,'utf8')); if (!j.dist || !j.dist.attestations) { console.error('no provenance attestation on core'); process.exit(1); } console.log('provenance:', j.dist.attestations.url)"
 

--- a/packages/dev/cad-cloud-sdk/package.json
+++ b/packages/dev/cad-cloud-sdk/package.json
@@ -19,7 +19,8 @@
         "./pipeline": {
             "types": "./dist/types/pipeline-operations.d.ts",
             "default": "./dist/types/pipeline-operations.js"
-        }
+        },
+        "./package.json": "./package.json"
     },
     "files": [
         "dist",

--- a/scripts/check-tarballs.mjs
+++ b/scripts/check-tarballs.mjs
@@ -129,6 +129,12 @@ for (const { dir, fromDist } of [...distProjects, ...rootProjects]) {
             if (/^(workspace|link|file|portal):/.test(String(spec))) fail(`${manifest.name} ${field}.${name} = ${spec} would only resolve inside this workspace`);
         }
     }
+    // A published exports map is a closed door: every subpath not named in it is refused. Tooling
+    // reads a package's own manifest as a matter of course - the install smoke does - so a map that
+    // omits ./package.json breaks consumers in a way no import of the package itself reveals.
+    if (manifest.exports && typeof manifest.exports === "object" && !("./package.json" in manifest.exports)) {
+        fail(`${manifest.name} publishes an exports map without "./package.json", so anything reading its manifest - tooling, the install smoke - fails with ERR_PACKAGE_PATH_NOT_EXPORTED. Add "./package.json": "./package.json" to it.`);
+    }
     checkNothingSilentlyStripped(manifest.name, publishDir, fromDist ? ["."] : (manifest.files ?? ["."]));
     // npm 11.6 answers with an array of one entry; a later npm answers with the entry itself, and
     // destructuring the second as the first throws "object is not iterable" halfway through a

--- a/scripts/publish-packages.mjs
+++ b/scripts/publish-packages.mjs
@@ -124,7 +124,11 @@ for (const [i, tier] of tiers.entries()) {
         execFileSync("npm", cmd, { cwd: p.publishDir, stdio: "inherit" });
         publishedNow++;
     }
-    if (!dryRun && i < tiers.length - 1) await waitForTier(tier);
+    // Every tier, the last one included. The wait exists because a fresh publish can lag the
+    // registry's read path, and skipping it on the final tier assumed nothing else reads from it -
+    // but the install smoke that follows does, seconds later, and raced whichever package of that
+    // tier resolved slowest. A publish that worked then reported failure at the step after it.
+    if (!dryRun) await waitForTier(tier);
 }
 console.log(`\n${dryRun ? "dry run complete" : `published ${publishedNow}, skipped ${skipped} already on the registry`}`);
 if (!dryRun && tag === "next" && publishedNow) console.log(`published under next; promoting needs a token or an npm login, OIDC cannot:\n  ${[...packages.keys()].map((n) => `npm dist-tag add ${n}@${version} latest`).join(" && ")}`);


### PR DESCRIPTION
The tier loop polled the registry after each tier and skipped that wait on the final one, on the reasoning that no dependent tier was left to publish. The install smoke immediately after is a dependent: it installs the whole set from the registry, and the last tier had been on it for seconds. It failed with ETARGET on playcanvas while all thirteen packages were published and fine, which reads like a failed release and is not one.

The wait now runs after every tier. It costs one resolution check per package in the common case and removes a race that made a successful publish report failure.